### PR TITLE
Add support for returning a cert chain with the response.

### DIFF
--- a/cmd/client/app/root.go
+++ b/cmd/client/app/root.go
@@ -115,6 +115,10 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 		fmt.Println(resp.Payload.Certificate)
+		fmt.Println("-----CHAIN-----")
+		for _, c := range resp.Payload.Chain {
+			fmt.Println(c)
+		}
 
 		return nil
 	},

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58,3 +58,7 @@ definitions:
     properties:
       certificate:
         type: string
+      chain:
+        type: array
+        items:
+          type: string

--- a/pkg/api/signing_cert.go
+++ b/pkg/api/signing_cert.go
@@ -64,7 +64,11 @@ func SigningCertHandler(params operations.SigningCertParams, principal interface
 		log.Logger.Info("error getting cert", err)
 		return middleware.Error(http.StatusInternalServerError, err)
 	}
-
 	metricNewEntries.Inc()
-	return operations.NewSigningCertCreated().WithPayload(&models.SubmitSuccess{Certificate: resp.PemCertificate})
+
+	ret := &models.SubmitSuccess{
+		Certificate: resp.PemCertificate,
+		Chain:       resp.PemCertificateChain,
+	}
+	return operations.NewSigningCertCreated().WithPayload(ret)
 }

--- a/pkg/generated/models/submit_success.go
+++ b/pkg/generated/models/submit_success.go
@@ -34,6 +34,9 @@ type SubmitSuccess struct {
 
 	// certificate
 	Certificate string `json:"certificate,omitempty"`
+
+	// chain
+	Chain []string `json:"chain"`
 }
 
 // Validate validates this submit success

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -118,6 +118,12 @@ func init() {
       "properties": {
         "certificate": {
           "type": "string"
+        },
+        "chain": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }
@@ -214,6 +220,12 @@ func init() {
       "properties": {
         "certificate": {
           "type": "string"
+        },
+        "chain": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
If we introduce intermediary CAs, we'll need these.

Signed-off-by: Dan Lorenc <dlorenc@google.com>