### PR TITLE
Use 'Authorization Code with PKCE' OAuth2 flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@
 .history/
 
 #output binaries
+client
 server

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all test clean lint gosec
 
-all: server
+all: server client
 
 GENSRC = pkg/generated/models/%.go pkg/generated/restapi/%.go
 OPENAPIDEPS = openapi.yaml
@@ -8,7 +8,7 @@ SRCS = $(shell find cmd -iname "*.go") $(shell find pkg -iname "*.go"|grep -v pk
 
 $(GENSRC): $(OPENAPIDEPS)
 	swagger generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A fulcio_server --exclude-spec --flag-strategy=pflag --default-produces application/json
-	swagger generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --default-consumes application/json\;q=1
+	swagger generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --default-consumes application/json
 
 # this exists to override pattern match rule above since this file is in the generated directory but should not be treated as generated code
 pkg/generated/restapi/configure_fulcio_server.go: $(OPENAPIDEPS)
@@ -23,11 +23,14 @@ gosec:
 server: $(SRCS)
 	go build ./cmd/server
 
+client: $(SRCS)
+	go build ./cmd/client
+
 test:
 	go test ./...
 
 clean:
-	rm -rf server
+	rm -rf server client
 
 up:
 	docker-compose -f docker-compose.yml build

--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -55,6 +55,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logType, "log_type", "dev", "logger type to use (dev/prod)")
 
 	rootCmd.PersistentFlags().String("gcp_private_ca_parent", "", "private ca parent: /projects/<project>/locations/<location>/<name>")
+	rootCmd.PersistentFlags().String("oidc-issuer", "https://accounts.google.com", "OIDC provider to be used to issue ID token")
+	rootCmd.PersistentFlags().String("oidc-client-id", "237800849078-rmntmr1b2tcu20kpid66q5dbh1vdt7aj.apps.googleusercontent.com", "client ID for application")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,6 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
-cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
@@ -13,7 +12,6 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
-cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
@@ -132,7 +130,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
@@ -435,10 +432,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -670,7 +665,6 @@ golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 h1:xYJJ3S178yv++9zXV/hnr29plCAGO9vAFG9dorqaFQc=
 golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -695,7 +689,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -759,10 +752,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxW
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -941,7 +932,6 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
@@ -972,7 +962,6 @@ google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,15 +6,15 @@ schemes: [http, https]
 host: fulcio.sigstore.dev
 basePath: /api/v1
 securityDefinitions:
-  key:
+  Bearer:
     type: apiKey
     in: header
-    name: X-Access-Token
+    name: Authorization
 paths:
   /signingCert:
     post:
       security:
-        - key: []
+        - Bearer: []
       description: 'create a cert, return content with a location header (with URL to CTL entry)'
       operationId: signingCert
       consumes:

--- a/pkg/api/signing_cert.go
+++ b/pkg/api/signing_cert.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/sigstore/fulcio/pkg/log"
 
-	"github.com/coreos/go-oidc"
-
 	"github.com/go-openapi/runtime/middleware"
 	fca "github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/generated/models"
@@ -47,15 +45,15 @@ func SigningCertHandler(params operations.SigningCertParams, principal interface
 		Type:  "PUBLIC KEY",
 	})
 
-	userInfo := principal.(*oidc.UserInfo)
+	email := principal.(string)
 
 	// Check the proof
-	if !fca.Check(dec, string(params.Submitcsr.Proof), userInfo.Email) {
+	if !fca.Check(dec, string(params.Submitcsr.Proof), email) {
 		log.Logger.Info("email address was not signed correctly")
 		return middleware.Error(http.StatusBadRequest, "email address was not signed correctly")
 	}
 	// Now issue cert!
-	req := fca.Req(userInfo.Email, pemBytes)
+	req := fca.Req(email, pemBytes)
 
 	resp, err := fca.Client.CreateCertificate(ctx, req)
 	if err != nil {

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -51,7 +51,7 @@ func init() {
       "post": {
         "security": [
           {
-            "key": []
+            "Bearer": []
           }
         ],
         "description": "create a cert, return content with a location header (with URL to CTL entry)",
@@ -129,9 +129,9 @@ func init() {
     }
   },
   "securityDefinitions": {
-    "key": {
+    "Bearer": {
       "type": "apiKey",
-      "name": "X-Access-Token",
+      "name": "Authorization",
       "in": "header"
     }
   }
@@ -153,7 +153,7 @@ func init() {
       "post": {
         "security": [
           {
-            "key": []
+            "Bearer": []
           }
         ],
         "description": "create a cert, return content with a location header (with URL to CTL entry)",
@@ -231,9 +231,9 @@ func init() {
     }
   },
   "securityDefinitions": {
-    "key": {
+    "Bearer": {
       "type": "apiKey",
-      "name": "X-Access-Token",
+      "name": "Authorization",
       "in": "header"
     }
   }

--- a/pkg/generated/restapi/operations/fulcio_server_api.go
+++ b/pkg/generated/restapi/operations/fulcio_server_api.go
@@ -63,9 +63,9 @@ func NewFulcioServerAPI(spec *loads.Document) *FulcioServerAPI {
 			return middleware.NotImplemented("operation SigningCert has not yet been implemented")
 		}),
 
-		// Applies when the "X-Access-Token" header is set
-		KeyAuth: func(token string) (interface{}, error) {
-			return nil, errors.NotImplemented("api key auth (key) X-Access-Token from header param [X-Access-Token] has not yet been implemented")
+		// Applies when the "Authorization" header is set
+		BearerAuth: func(token string) (interface{}, error) {
+			return nil, errors.NotImplemented("api key auth (Bearer) Authorization from header param [Authorization] has not yet been implemented")
 		},
 		// default authorizer is authorized meaning no requests are blocked
 		APIAuthorizer: security.Authorized(),
@@ -103,9 +103,9 @@ type FulcioServerAPI struct {
 	//   - application/json
 	JSONProducer runtime.Producer
 
-	// KeyAuth registers a function that takes a token and returns a principal
-	// it performs authentication based on an api key X-Access-Token provided in the header
-	KeyAuth func(string) (interface{}, error)
+	// BearerAuth registers a function that takes a token and returns a principal
+	// it performs authentication based on an api key Authorization provided in the header
+	BearerAuth func(string) (interface{}, error)
 
 	// APIAuthorizer provides access control (ACL/RBAC/ABAC) by providing access to the request and authenticated principal
 	APIAuthorizer runtime.Authorizer
@@ -188,8 +188,8 @@ func (o *FulcioServerAPI) Validate() error {
 		unregistered = append(unregistered, "JSONProducer")
 	}
 
-	if o.KeyAuth == nil {
-		unregistered = append(unregistered, "XAccessTokenAuth")
+	if o.BearerAuth == nil {
+		unregistered = append(unregistered, "AuthorizationAuth")
 	}
 
 	if o.SigningCertHandler == nil {
@@ -213,9 +213,9 @@ func (o *FulcioServerAPI) AuthenticatorsFor(schemes map[string]spec.SecuritySche
 	result := make(map[string]runtime.Authenticator)
 	for name := range schemes {
 		switch name {
-		case "key":
+		case "Bearer":
 			scheme := schemes[name]
-			result[name] = o.APIKeyAuthenticator(scheme.Name, scheme.In, o.KeyAuth)
+			result[name] = o.APIKeyAuthenticator(scheme.Name, scheme.In, o.BearerAuth)
 
 		}
 	}

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -23,11 +23,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/coreos/go-oidc"
 	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 
@@ -40,54 +42,103 @@ const htmlPage = `<html>
 </html>
 `
 
-// AccessTokenGetter is a type to get access tokens for oauth flows
-type AccessTokenGetter struct {
+// IDTokenGetter is a type to get ID tokens for oauth flows
+type IDTokenGetter struct {
 	MessagePrinter func(url string)
 	HTMLPage       string
 }
 
-// DefaultAccessTokenGetter is the default implementation.
+type OIDCIDToken struct {
+	RawString   string
+	ParsedToken *oidc.IDToken
+}
+
+// DefaultIDTokenGetter is the default implementation.
 // The HTML page and message printed to the terminal can be customized.
-var DefaultAccessTokenGetter = AccessTokenGetter{
+var DefaultIDTokenGetter = IDTokenGetter{
 	MessagePrinter: func(url string) { fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", url) },
 	HTMLPage:       htmlPage,
 }
 
-// GetAccessToken is the default implementation
-var GetAccessToken = DefaultAccessTokenGetter.getAccessToken
+// GetIDToken is the default implementation
+var GetIDToken = DefaultIDTokenGetter.getIDToken
 
-func (a *AccessTokenGetter) getAccessToken(p *oidc.Provider, cfg oauth2.Config) (string, error) {
+func (i *IDTokenGetter) getIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
+	redirectURL, err := url.Parse(cfg.RedirectURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// generate random fields
 	stateToken, err := randStr()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
-	url := cfg.AuthCodeURL(stateToken, oauth2.AccessTypeOnline)
-	fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", url)
-	if err := open.Run(url); err != nil {
-		return "", err
-	}
-
-	code, err := getCodeFromLocalServer(stateToken)
-	token, err := cfg.Exchange(context.Background(), code)
+	nonce, err := randStr()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return token.AccessToken, nil
+	pkce, _ := NewPKCE(PKCES256)
+
+	authCodeURL := cfg.AuthCodeURL(stateToken, append(pkce.AuthURLOpts(), oauth2.AccessTypeOnline, oidc.Nonce(nonce))...)
+	fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", authCodeURL)
+	if err := open.Run(authCodeURL); err != nil {
+		return nil, err
+	}
+
+	code, err := getCodeFromLocalServer(stateToken, redirectURL)
+	if err != nil {
+		return nil, err
+	}
+	token, err := cfg.Exchange(context.Background(), code, append(pkce.TokenURLOpts(), oidc.Nonce(nonce))...)
+	if err != nil {
+		return nil, err
+	}
+
+	// requesting 'openid' scope should ensure an id_token is given when exchanging the code for an access token
+	idToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return nil, errors.New("id_token not present")
+	}
+
+	// verify nonce, client ID, access token hash before using it
+	verifier := p.Verifier(&oidc.Config{ClientID: viper.GetString("oidc-client-id")})
+	parsedIDToken, err := verifier.Verify(context.Background(), idToken)
+	if err != nil {
+		return nil, err
+	}
+	if parsedIDToken.Nonce != nonce {
+		return nil, errors.New("nonce does not match value sent")
+	}
+	if parsedIDToken.AccessTokenHash != "" {
+		if err := parsedIDToken.VerifyAccessToken(token.AccessToken); err != nil {
+			return nil, err
+		}
+	}
+
+	returnToken := OIDCIDToken{
+		RawString:   idToken,
+		ParsedToken: parsedIDToken,
+	}
+	return &returnToken, nil
 }
 
-func getCodeFromLocalServer(state string) (string, error) {
+func getCodeFromLocalServer(state string, redirectURL *url.URL) (string, error) {
 	doneCh := make(chan string)
 	errCh := make(chan error)
 	m := http.NewServeMux()
 	s := http.Server{
-		Addr:    "localhost:5556",
+		Addr:    redirectURL.Host,
 		Handler: m,
 	}
-	defer s.Shutdown(context.Background())
+	defer func() {
+		_ = s.Shutdown(context.Background())
+	}()
 
 	go func() {
-		m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		m.HandleFunc(redirectURL.Path, func(w http.ResponseWriter, r *http.Request) {
+			// even though these are fetched from the FormValue method,
+			// these are supplied as query parameters
 			if r.FormValue("state") != state {
 				errCh <- errors.New("invalid state token")
 				return
@@ -112,13 +163,14 @@ func getCodeFromLocalServer(state string) (string, error) {
 }
 
 func randStr() (string, error) {
-	buf := [10]byte{}
-	n, err := rand.Read(buf[:])
+	len := 32
+	b := make([]byte, len)
+	n, err := rand.Read(b)
 	if err != nil {
 		return "", err
-	}
-	if n != len(buf) {
+	} else if n != len {
 		return "", errors.New("short read")
 	}
-	return base64.StdEncoding.EncodeToString(buf[:]), nil
+
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
 }

--- a/pkg/oauthflow/pkce.go
+++ b/pkg/oauthflow/pkce.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2021 Bob Callaway <bcallawa@redhat.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package oauthflow
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+
+	"golang.org/x/oauth2"
+)
+
+type PKCEMethod string
+
+const (
+	PKCEPlain PKCEMethod = "plain"
+	PKCES256  PKCEMethod = "S256"
+)
+
+type PKCE struct {
+	Challenge string
+	Method    PKCEMethod
+	Value     string
+}
+
+func NewPKCE(method PKCEMethod) (*PKCE, error) {
+	switch method {
+	case PKCEPlain, PKCES256:
+	default:
+		return nil, errors.New("invalid PKCE method requested")
+	}
+
+	value, err := randStr()
+	if err != nil {
+		return nil, err
+	}
+
+	var challenge string
+	if method == PKCES256 {
+		h := sha256.New()
+		_, _ = h.Write([]byte(value))
+		challenge = base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	} else {
+		challenge = value
+	}
+
+	return &PKCE{
+		Challenge: challenge,
+		Method:    method,
+		Value:     value,
+	}, nil
+}
+
+func (p *PKCE) AuthURLOpts() []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("code_challenge_method", string(p.Method)),
+		oauth2.SetAuthURLParam("code_challenge", p.Challenge),
+	}
+}
+
+func (p *PKCE) TokenURLOpts() []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("code_verifier", p.Value),
+	}
+}


### PR DESCRIPTION
This change adds the use of the PKCE challenge and verifier into the
OAuth2 flow in the CLI to be compliant with RFC 8252. It also adds the
optional nonce parameter.

It also converts the Fulcio server to using the raw id_token as the
Authorization header Bearer token, and verifies that:
 - the token was signed by the specified OIDC identity provider
 - the client ID matches what is expected
 - the email address in the id_token was verified at some point in past

This change also moves the OIDC settings into command line arguments,
and shrinks the number of HTTP calls used in the OAuth2 dance.

Signed-off-by: Bob Callaway <bcallawa@redhat.com>