### PR TITLE
Use a once block instead of an init.

### DIFF
--- a/pkg/api/signing_cert.go
+++ b/pkg/api/signing_cert.go
@@ -55,7 +55,7 @@ func SigningCertHandler(params operations.SigningCertParams, principal interface
 	// Now issue cert!
 	req := fca.Req(email, pemBytes)
 
-	resp, err := fca.Client.CreateCertificate(ctx, req)
+	resp, err := fca.Client().CreateCertificate(ctx, req)
 	if err != nil {
 		log.Logger.Info("error getting cert", err)
 		return middleware.Error(http.StatusInternalServerError, err)

--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"sync"
 
 	"github.com/spf13/viper"
 
@@ -30,14 +31,20 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-var Client *privateca.CertificateAuthorityClient
+var once sync.Once
 
-func init() {
-	c, err := privateca.NewCertificateAuthorityClient(context.Background())
-	if err != nil {
-		panic(err)
-	}
-	Client = c
+func Client() *privateca.CertificateAuthorityClient {
+	var c *privateca.CertificateAuthorityClient
+
+	// Use a once block to avoid creating a new client every time.
+	once.Do(func() {
+		var err error
+		c, err = privateca.NewCertificateAuthorityClient(context.Background())
+		if err != nil {
+			panic(err)
+		}
+	})
+	return c
 }
 
 func Check(pub []byte, proof string, email string) bool {


### PR DESCRIPTION
This will let tests pass since there are no credentials in GitHub Actions.

Signed-off-by: Dan Lorenc <dlorenc@google.com>