### PR TITLE
fail build if diff exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: CI
 env:
-  GOVERSION: 1.15.6
+  GOVERSION: 1.16.3
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
@@ -28,7 +28,7 @@ jobs:
           go-version: ${{ env.GOVERSION }}
       # Download go-swagger
       - name: download go-swagger
-        run : go get -u github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
+        run : go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
       - name: Validate OpenAPI with Swagger
         run: swagger validate openapi.yaml
       # Make it
@@ -50,4 +50,4 @@ jobs:
         with:
           args: ./...
       - name: Ensure no files were modified as a result of the build
-        run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff
+        run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff --exit-code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/fulcio
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.80.0

--- a/pkg/generated/client/operations/signing_cert_parameters.go
+++ b/pkg/generated/client/operations/signing_cert_parameters.go
@@ -35,59 +35,73 @@ import (
 	"github.com/sigstore/fulcio/pkg/generated/models"
 )
 
-// NewSigningCertParams creates a new SigningCertParams object
-// with the default values initialized.
+// NewSigningCertParams creates a new SigningCertParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewSigningCertParams() *SigningCertParams {
-	var ()
 	return &SigningCertParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewSigningCertParamsWithTimeout creates a new SigningCertParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewSigningCertParamsWithTimeout(timeout time.Duration) *SigningCertParams {
-	var ()
 	return &SigningCertParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewSigningCertParamsWithContext creates a new SigningCertParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewSigningCertParamsWithContext(ctx context.Context) *SigningCertParams {
-	var ()
 	return &SigningCertParams{
-
 		Context: ctx,
 	}
 }
 
 // NewSigningCertParamsWithHTTPClient creates a new SigningCertParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewSigningCertParamsWithHTTPClient(client *http.Client) *SigningCertParams {
-	var ()
 	return &SigningCertParams{
 		HTTPClient: client,
 	}
 }
 
-/*SigningCertParams contains all the parameters to send to the API endpoint
-for the signing cert operation typically these are written to a http.Request
+/* SigningCertParams contains all the parameters to send to the API endpoint
+   for the signing cert operation.
+
+   Typically these are written to a http.Request.
 */
 type SigningCertParams struct {
 
-	/*CertificateRequest
-	  Request for signing certificate
+	/* CertificateRequest.
 
+	   Request for signing certificate
 	*/
 	CertificateRequest *models.CertificateRequest
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the signing cert params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SigningCertParams) WithDefaults() *SigningCertParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the signing cert params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SigningCertParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the signing cert params
@@ -141,7 +155,6 @@ func (o *SigningCertParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
 	if o.CertificateRequest != nil {
 		if err := r.SetBodyParam(o.CertificateRequest); err != nil {
 			return err

--- a/pkg/generated/client/operations/signing_cert_responses.go
+++ b/pkg/generated/client/operations/signing_cert_responses.go
@@ -75,7 +75,7 @@ func NewSigningCertCreated() *SigningCertCreated {
 	return &SigningCertCreated{}
 }
 
-/*SigningCertCreated handles this case with default header values.
+/* SigningCertCreated describes a response with status code 201, with default header values.
 
 Generated Certificate Chain
 */
@@ -86,7 +86,6 @@ type SigningCertCreated struct {
 func (o *SigningCertCreated) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertCreated  %+v", 201, o.Payload)
 }
-
 func (o *SigningCertCreated) GetPayload() string {
 	return o.Payload
 }
@@ -106,7 +105,7 @@ func NewSigningCertBadRequest() *SigningCertBadRequest {
 	return &SigningCertBadRequest{}
 }
 
-/*SigningCertBadRequest handles this case with default header values.
+/* SigningCertBadRequest describes a response with status code 400, with default header values.
 
 The content supplied to the server was invalid
 */
@@ -119,15 +118,18 @@ type SigningCertBadRequest struct {
 func (o *SigningCertBadRequest) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *SigningCertBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// response header Content-Type
-	o.ContentType = response.GetHeader("Content-Type")
+	// hydrates response header Content-Type
+	hdrContentType := response.GetHeader("Content-Type")
+
+	if hdrContentType != "" {
+		o.ContentType = hdrContentType
+	}
 
 	o.Payload = new(models.Error)
 
@@ -144,13 +146,14 @@ func NewSigningCertUnauthorized() *SigningCertUnauthorized {
 	return &SigningCertUnauthorized{}
 }
 
-/*SigningCertUnauthorized handles this case with default header values.
+/* SigningCertUnauthorized describes a response with status code 401, with default header values.
 
 The request could not be authorized
 */
 type SigningCertUnauthorized struct {
 	ContentType string
-	/*Information about required authentication to access server
+
+	/* Information about required authentication to access server
 	 */
 	WWWAuthenticate string
 
@@ -160,18 +163,25 @@ type SigningCertUnauthorized struct {
 func (o *SigningCertUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *SigningCertUnauthorized) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// response header Content-Type
-	o.ContentType = response.GetHeader("Content-Type")
+	// hydrates response header Content-Type
+	hdrContentType := response.GetHeader("Content-Type")
 
-	// response header WWW-Authenticate
-	o.WWWAuthenticate = response.GetHeader("WWW-Authenticate")
+	if hdrContentType != "" {
+		o.ContentType = hdrContentType
+	}
+
+	// hydrates response header WWW-Authenticate
+	hdrWWWAuthenticate := response.GetHeader("WWW-Authenticate")
+
+	if hdrWWWAuthenticate != "" {
+		o.WWWAuthenticate = hdrWWWAuthenticate
+	}
 
 	o.Payload = new(models.Error)
 
@@ -190,13 +200,12 @@ func NewSigningCertDefault(code int) *SigningCertDefault {
 	}
 }
 
-/*SigningCertDefault handles this case with default header values.
+/* SigningCertDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
 type SigningCertDefault struct {
 	_statusCode int
-
 	ContentType string
 
 	Payload *models.Error
@@ -210,15 +219,18 @@ func (o *SigningCertDefault) Code() int {
 func (o *SigningCertDefault) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCert default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *SigningCertDefault) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// response header Content-Type
-	o.ContentType = response.GetHeader("Content-Type")
+	// hydrates response header Content-Type
+	hdrContentType := response.GetHeader("Content-Type")
+
+	if hdrContentType != "" {
+		o.ContentType = hdrContentType
+	}
 
 	o.Payload = new(models.Error)
 

--- a/pkg/generated/models/certificate_request.go
+++ b/pkg/generated/models/certificate_request.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -86,6 +87,34 @@ func (m *CertificateRequest) validateSignedEmailAddress(formats strfmt.Registry)
 
 	if err := validate.Required("signedEmailAddress", "body", m.SignedEmailAddress); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this certificate request based on the context it is used
+func (m *CertificateRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *CertificateRequest) contextValidatePublicKey(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PublicKey != nil {
+		if err := m.PublicKey.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("publicKey")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -189,6 +218,11 @@ func (m *CertificateRequestPublicKey) validateContent(formats strfmt.Registry) e
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this certificate request public key based on context it is used
+func (m *CertificateRequestPublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/error.go
+++ b/pkg/generated/models/error.go
@@ -23,6 +23,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -41,6 +43,11 @@ type Error struct {
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this error based on context it is used
+func (m *Error) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/restapi/operations/fulcio_server_api.go
+++ b/pkg/generated/restapi/operations/fulcio_server_api.go
@@ -93,9 +93,11 @@ type FulcioServerAPI struct {
 	// BasicAuthenticator generates a runtime.Authenticator from the supplied basic auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BasicAuthenticator func(security.UserPassAuthentication) runtime.Authenticator
+
 	// APIKeyAuthenticator generates a runtime.Authenticator from the supplied token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	APIKeyAuthenticator func(string, string, security.TokenAuthentication) runtime.Authenticator
+
 	// BearerAuthenticator generates a runtime.Authenticator from the supplied bearer token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
@@ -117,6 +119,7 @@ type FulcioServerAPI struct {
 
 	// SigningCertHandler sets the operation handler for the signing cert operation
 	SigningCertHandler SigningCertHandler
+
 	// ServeError is called when an error is received, there is a default handler
 	// but you can set your own with this
 	ServeError func(http.ResponseWriter, *http.Request, error)

--- a/pkg/generated/restapi/operations/signing_cert.go
+++ b/pkg/generated/restapi/operations/signing_cert.go
@@ -48,7 +48,7 @@ func NewSigningCert(ctx *middleware.Context, handler SigningCertHandler) *Signin
 	return &SigningCert{Context: ctx, Handler: handler}
 }
 
-/*SigningCert swagger:route POST /signingCert signingCert
+/* SigningCert swagger:route POST /signingCert signingCert
 
 create a cert, return content with a location header (with URL to CTL entry)
 
@@ -64,7 +64,6 @@ func (o *SigningCert) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		r = rCtx
 	}
 	var Params = NewSigningCertParams()
-
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -84,7 +83,6 @@ func (o *SigningCert) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/signing_cert_parameters.go
+++ b/pkg/generated/restapi/operations/signing_cert_parameters.go
@@ -23,18 +23,21 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	"github.com/sigstore/fulcio/pkg/generated/models"
 )
 
 // NewSigningCertParams creates a new SigningCertParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewSigningCertParams() SigningCertParams {
 
 	return SigningCertParams{}
@@ -77,6 +80,11 @@ func (o *SigningCertParams) BindRequest(r *http.Request, route *middleware.Match
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}
 


### PR DESCRIPTION
Right now the build tries to detect mismatches between what is in the change versus any changes actually occurred from a clean rebuild (e.g. missed checking in any updates to generated code). However if those are present, the build logs print out the difference but do not cause the build to fail.

Also bumps GOVERSION to match what is used in Dockerfile so we don't have go.mod or go.sum as a reason for above.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
