### PR TITLE
Add Key Encipherment to satisfy Microsoft code signing cert requirements

### DIFF
--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -78,6 +78,7 @@ func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRe
 								KeyUsage: &privatecapb.KeyUsage{
 									BaseKeyUsage: &privatecapb.KeyUsage_KeyUsageOptions{
 										DigitalSignature: true,
+										KeyEncipherment: true,
 									},
 									ExtendedKeyUsage: &privatecapb.KeyUsage_ExtendedKeyUsageOptions{
 										CodeSigning: true,


### PR DESCRIPTION
Signed-off-by: Christian Pearce <christian@pearcec.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
