### PR TITLE
Query PublicKey_KeyType

### DIFF
--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -21,6 +21,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"sync"
@@ -65,8 +67,28 @@ func CheckSignature(pub crypto.PublicKey, proof []byte, email string) error {
 	return nil
 }
 
+func getPubKeyType(pemBytes []byte)  interface{} {
+	// Returns the PublicKey type required by gcp privateca (to handle both PEM_RSA_KEY / PEM_EC_KEY)
+	// https://pkg.go.dev/google.golang.org/genproto/googleapis/cloud/security/privateca/v1beta1#PublicKey_KeyType
+	block, _ := pem.Decode(pemBytes)
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		panic("failed to parse public key: " + err.Error())
+	}
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		return privatecapb.PublicKey_KeyType(1)
+	case *ecdsa.PublicKey:
+		return privatecapb.PublicKey_KeyType(2)
+	default:
+		panic(fmt.Errorf("unknown public key type: %v", pub))
+	}
+	return nil
+}
+
 func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRequest {
 	// TODO, use the right fields :)
+	pubkey_type := getPubKeyType(pemBytes)
 	return &privatecapb.CreateCertificateRequest{
 		Parent: parent,
 		Certificate: &privatecapb.Certificate{
@@ -74,7 +96,7 @@ func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRe
 			CertificateConfig: &privatecapb.Certificate_Config{
 				Config: &privatecapb.CertificateConfig{
 					PublicKey: &privatecapb.PublicKey{
-						Type: privatecapb.PublicKey_PEM_EC_KEY,
+						Type: pubkey_type.(privatecapb.PublicKey_KeyType),
 						Key:  pemBytes,
 					},
 					ReusableConfig: &privatecapb.ReusableConfigWrapper{


### PR DESCRIPTION
This is required to send the correct Key Type needed
by GCP CreateCertificateRequest and allow the signing
of both RSA and ECDSA

Signed-off-by: Luke Hinds <lhinds@redhat.com>
