### PR TITLE
Skip the CT log upload if no ct server is configured.

### DIFF
--- a/pkg/api/signing_cert.go
+++ b/pkg/api/signing_cert.go
@@ -78,13 +78,17 @@ func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDT
 	// Submit to CTL
 	log.Logger.Info("Submitting CTL inclusion for OIDC grant: ", emailAddress)
 	ctURL := viper.GetString("ct-log-url")
-	c := ctl.New(ctURL)
-	ct, err := c.AddChain(resp.PemCertificate, resp.PemCertificateChain)
-	if err != nil {
-		return handleFulcioAPIError(params, http.StatusInternalServerError, err, fmt.Sprintf(failedToEnterCertInCTL, ctURL))
+	if ctURL != "" {
+		c := ctl.New(ctURL)
+		ct, err := c.AddChain(resp.PemCertificate, resp.PemCertificateChain)
+		if err != nil {
+			return handleFulcioAPIError(params, http.StatusInternalServerError, err, fmt.Sprintf(failedToEnterCertInCTL, ctURL))
+		}
+		log.Logger.Info("CTL Submission Signature Received: ", ct.Signature)
+		log.Logger.Info("CTL Submission ID Received: ", ct.ID)
+	} else {
+		log.Logger.Info("Skipping CT log upload.")
 	}
-	log.Logger.Info("CTL Submission Signature Received: ", ct.Signature)
-	log.Logger.Info("CTL Submission ID Received: ", ct.ID)
 
 	metricNewEntries.Inc()
 


### PR DESCRIPTION
This makes local development a bit easier.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

