### PR TITLE
Remove the common name field from the certs.

### DIFF
--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -113,12 +113,8 @@ func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRe
 						},
 					},
 					SubjectConfig: &privatecapb.CertificateConfig_SubjectConfig{
-						CommonName: email,
 						SubjectAltName: &privatecapb.SubjectAltNames{
 							EmailAddresses: []string{email},
-						},
-						Subject: &privatecapb.Subject{
-							Organization: email,
 						},
 					},
 				},


### PR DESCRIPTION
This was overkill and the field is deprecated anyway. We only check the SAN.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
