### PR TITLE
Support SPIFFE challenges instead of just emails.

### DIFF
--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -24,11 +24,13 @@ data:
       "OIDCIssuers": {
         "https://accounts.google.com": {
           "IssuerURL": "https://accounts.google.com",
-          "ClientID": "sigstore"
+          "ClientID": "sigstore",
+          "Type": "email"
         },
         "https://oauth2.sigstore.dev/auth": {
           "IssuerURL": "https://oauth2.sigstore.dev/auth",
           "ClientID": "sigstore"
+          "Type": "email"
         }
       }
     }

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -29,12 +29,10 @@ import (
 )
 
 const (
-	malformedPublicKey     = "The public key supplied in the request could not be parsed"
 	invalidSignature       = "The signature supplied in the request could not be verified"
 	failedToCreateCert     = "Error creating certificate"
 	failedToEnterCertInCTL = "Error entering certificate in CTL @ '%v'"
 	invalidCredentials     = "There was an error processing the credentials for this request"
-	emailNotVerified       = "The identity provider reported that the email address for this request has not be verified"
 )
 
 func errorMsg(message string, code int) *models.Error {

--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -85,7 +85,7 @@ func getPubKeyType(pemBytes []byte) interface{} {
 	}
 }
 
-func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRequest {
+func Req(parent string, subject *privatecapb.CertificateConfig_SubjectConfig, pemBytes []byte) *privatecapb.CreateCertificateRequest {
 	// TODO, use the right fields :)
 	pubkeyType := getPubKeyType(pemBytes)
 	return &privatecapb.CreateCertificateRequest{
@@ -112,13 +112,25 @@ func Req(parent, email string, pemBytes []byte) *privatecapb.CreateCertificateRe
 							},
 						},
 					},
-					SubjectConfig: &privatecapb.CertificateConfig_SubjectConfig{
-						SubjectAltName: &privatecapb.SubjectAltNames{
-							EmailAddresses: []string{email},
-						},
-					},
+					SubjectConfig: subject,
 				},
 			},
+		},
+	}
+}
+
+func EmailSubject(email string) *privatecapb.CertificateConfig_SubjectConfig {
+	return &privatecapb.CertificateConfig_SubjectConfig{
+		SubjectAltName: &privatecapb.SubjectAltNames{
+			EmailAddresses: []string{email},
+		}}
+}
+
+// SPIFFE IDs go as "Uris" according to the spec: https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md
+func SpiffeSubject(id string) *privatecapb.CertificateConfig_SubjectConfig {
+	return &privatecapb.CertificateConfig_SubjectConfig{
+		SubjectAltName: &privatecapb.SubjectAltNames{
+			Uris: []string{id},
 		},
 	}
 }

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -1,0 +1,100 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package challenges
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/sigstore/fulcio/pkg/config"
+
+	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1beta1"
+
+	"github.com/sigstore/fulcio/pkg/ca"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/oauthflow"
+)
+
+func Email(ctx context.Context, principal *oidc.IDToken, pubKey, challenge []byte) (*privatecapb.CertificateConfig_SubjectConfig, error) {
+	emailAddress, emailVerified, err := oauthflow.EmailFromIDToken(principal)
+	if !emailVerified {
+		return nil, errors.New("email_verified claim was false")
+	} else if err != nil {
+		return nil, err
+	}
+
+	pkixPubKey, err := x509.ParsePKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the proof
+	if err := ca.CheckSignature(pkixPubKey, challenge, emailAddress); err != nil {
+		return nil, err
+	}
+
+	// Now issue cert!
+	return ca.EmailSubject(emailAddress), nil
+}
+
+func Spiffe(ctx context.Context, principal *oidc.IDToken, pubKey, challenge []byte) (*privatecapb.CertificateConfig_SubjectConfig, error) {
+
+	spiffeID := principal.Subject
+
+	pkixPubKey, err := x509.ParsePKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	cfg := config.Config()
+
+	// The Spiffe ID must be a subdomain of the issuer (spiffe://foo.example.com -> example.com/...)
+	u, err := url.Parse(cfg.OIDCIssuers[principal.Issuer].IssuerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerHostname := u.Hostname()
+	if !isSpiffeIDAllowed(u.Hostname(), spiffeID) {
+		return nil, fmt.Errorf("%s is not allowed for %s", spiffeID, issuerHostname)
+	}
+
+	// Check the proof
+	if err := ca.CheckSignature(pkixPubKey, challenge, spiffeID); err != nil {
+		return nil, err
+	}
+
+	// Now issue cert!
+	return ca.SpiffeSubject(spiffeID), nil
+}
+
+func isSpiffeIDAllowed(host, spiffeID string) bool {
+	// Strip spiffe://
+	name := strings.TrimPrefix(spiffeID, "spiffe://")
+
+	// get the host part
+	spiffeDomain := strings.Split(name, "/")[0]
+
+	if spiffeDomain == host {
+		return true
+	}
+	return strings.Contains(spiffeDomain, "."+host)
+
+}

--- a/pkg/challenges/challenges_test.go
+++ b/pkg/challenges/challenges_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package challenges
+
+import "testing"
+
+func Test_isSpiffeIDAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		spiffeID string
+		want     bool
+	}{
+		{
+			name:     "match",
+			host:     "foobar.com",
+			spiffeID: "spiffe://foobar.com/stuff",
+			want:     true,
+		},
+		{
+			name:     "subdomain match",
+			host:     "foobar.com",
+			spiffeID: "spiffe://spife.foobar.com/stuff",
+			want:     true,
+		},
+		{
+			name:     "subdomain mismatch",
+			host:     "foo.foobar.com",
+			spiffeID: "spiffe://spife.foobar.com/stuff",
+			want:     false,
+		},
+		{
+			name:     "inverted mismatch",
+			host:     "foo.foobar.com",
+			spiffeID: "spiffe://foobar.com/stuff",
+			want:     false,
+		},
+		{
+			name:     "no dot mismatch",
+			host:     "foobar.com",
+			spiffeID: "spiffe://foofoobar.com/stuff",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSpiffeIDAllowed(tt.host, tt.spiffeID); got != tt.want {
+				t.Errorf("isSpiffeIDAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,15 @@ type FulcioConfig struct {
 type OIDCIssuer struct {
 	IssuerURL string
 	ClientID  string
+	Type      IssuerType
 }
+
+type IssuerType string
+
+const (
+	IssuerTypeEmail  = "email"
+	IssuerTypeSpiffe = "spiffe"
+)
 
 func ParseConfig(b []byte) (FulcioConfig, error) {
 	cfg := FulcioConfig{}
@@ -45,10 +53,12 @@ var DefaultConfig = FulcioConfig{
 		"https://oauth2.sigstore.dev/auth": {
 			IssuerURL: "https://oauth2.sigstore.dev/auth",
 			ClientID:  "sigstore",
+			Type:      IssuerTypeEmail,
 		},
 		"https://accounts.google.com": {
 			IssuerURL: "https://accounts.google.com",
 			ClientID:  "sigstore",
+			Type:      IssuerTypeEmail,
 		},
 	},
 }
@@ -78,6 +88,6 @@ func Load(configPath string) error {
 		return err
 	}
 	config = &cfg
-	log.Logger.Info("Loaded config %v from %s", cfg, configPath)
+	log.Logger.Infof("Loaded config %v from %s", cfg, configPath)
 	return nil
 }


### PR DESCRIPTION
This also refactors the code a bit so each "issuer" can declare which
type of subject it will grant. The current types are email and spiffe.
Each type can set different fields in the final cert.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
