### PR TITLE
fulcio/e2e: add initial kind cluster deployment to test fulcio server

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -1,0 +1,61 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify-K8s
+
+on: [push, pull_request]
+
+jobs:
+  verify-k8s-manifests:
+    name: k8s manifest check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Install kubeval
+        run: go get github.com/instrumenta/kubeval
+      - run: kubeval config/*.yaml
+
+  verify-k8s-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Install ko
+        run: |
+          curl -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko && \
+          chmod +x ./ko && sudo mv ko /usr/local/bin/
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.1.0
+        with:
+          cluster_name: fulcio-cluster
+      - name: Deploy fulcio-dev
+        run: |
+          sed -i -e 's,memory: "1G",memory: "100m",g' ${{ github.workspace }}/config/deployment.yaml
+          sed -i -e 's,cpu: ".5",memory: "50m",g' ${{ github.workspace }}/config/deployment.yaml
+
+          kubectl create ns fulcio-dev
+
+          export KO_DOCKER_REPO=kind.local
+          export KIND_CLUSTER_NAME=fulcio-cluster
+          ko resolve -f config/ | kubectl apply -f -
+
+          kubectl wait --for=condition=Available --timeout=5m -n fulcio-dev deployment/fulcio-server
+
+          kubectl get po -n fulcio-dev

--- a/config/README.md
+++ b/config/README.md
@@ -1,30 +1,48 @@
 # GCP Project - Create a CA called "sigstore-test"
+
 - Devops tier (faster)
 - us-central1
 - Strongest EC
 - In UI, Go to policy, set max issuance to .138 Days :)
 
-path should be: --gcp_private_ca_parent=projects/project-rekor/locations/us-central1/certificateAuthorities/sigstore
+path should be: `--gcp_private_ca_parent=projects/project-rekor/locations/us-central1/certificateAuthorities/sigstore`
 
 # Namespace
 
 Let's run this in the `fulcio` namspace.
 
 Create a new workloadidentity SA and worklaod binding:
-gcloud iam service-accounts create fulcio-dev`
-gcloud iam service-accounts add-iam-policy-binding   --role roles/iam.workloadIdentityUser   --member "serviceAccount:project-rekor.svc.id.goog[fulcio-dev/default]"   fulcio-dev@project-rekor.iam.gserviceaccount.com
+
+```shell
+$ gcloud iam service-accounts create fulcio-dev
+
+$ gcloud iam service-accounts add-iam-policy-binding   --role roles/iam.workloadIdentityUser   --member "serviceAccount:project-rekor.svc.id.goog[fulcio-dev/default]"   fulcio-dev@project-rekor.iam.gserviceaccount.com
+```
 
 Create namespace:
-kubectl create ns fulcio-dev
+
+```shell
+$ kubectl create ns fulcio-dev
+```
 
 Annotate:
-kubectl annotate serviceaccount   --namespace fulcio-dev   default   iam.gke.io/gcp-service-account=fulcio-dev@project-rekor.iam.gserviceaccount.com
+
+```
+$ kubectl annotate serviceaccount \
+  --namespace fulcio-dev \
+  default iam.gke.io/gcp-service-account=fulcio-dev@project-rekor.iam.gserviceaccount.com
+```
 
 Test:
+
 ```
-kubectl run -it   --image google/cloud-sdk:slim   --serviceaccount default   --namespace fulcio-dev   workload-identity-test
+$ kubectl run -it --image google/cloud-sdk:slim \
+  --serviceaccount default \
+  --namespace fulcio-dev \
+  workload-identity-test
+
 # gcloud auth list
-                 Credentialed Accounts
+Credentialed Accounts
 ACTIVE  ACCOUNT
 *       fulcio-dev@project-rekor.iam.gserviceaccount.com
 ```
@@ -37,5 +55,9 @@ CA : -> Add Member -> fulcio-dev@project-rekor.iam.gserviceaccount.com -> Role -
 (TODO: create an intermediary, take this one offline)
 
 # Debug
-kubectl port-forward deployment/fulcio-server -n fulcio-dev 5555:5555
-kubectl logs -f deployment/fulcio-server -n fulcio-dev
+
+```shell
+$ kubectl port-forward deployment/fulcio-server -n fulcio-dev 5555:5555
+
+$ kubectl logs -f deployment/fulcio-server -n fulcio-dev
+```

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -61,6 +61,7 @@ spec:
       - name: fulcio-config
         configMap:
           name: fulcio-config
+
 ---
 apiVersion: v1
 kind: Service
@@ -75,4 +76,3 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 5555
----

--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -29,7 +29,7 @@ data:
         },
         "https://oauth2.sigstore.dev/auth": {
           "IssuerURL": "https://oauth2.sigstore.dev/auth",
-          "ClientID": "sigstore"
+          "ClientID": "sigstore",
           "Type": "email"
         }
       }

--- a/config/private-ca-secret-ci.yaml
+++ b/config/private-ca-secret-ci.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# used for CI only this Certificate is mention https://github.com/sigstore/fulcio/blob/main/config/DEVELOPMENT.md#testing-with-the-client
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: private-ca
+  namespace: fulcio-dev
+data:
+  connection: |
+    -----BEGIN CERTIFICATE-----
+    MIICyjCCAlCgAwIBAgITEfJ495apY+Xh6mwKJSeVKElaSjAKBggqhkjOPQQDAzAq
+    MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
+    MDMwNzE0NDU1N1oXDTIxMDMwNzE1MDU1MFowOjEbMBkGA1UECgwSbG9yZW5jLmRA
+    Z21haWwuY29tMRswGQYDVQQDDBJsb3JlbmMuZEBnbWFpbC5jb20wdjAQBgcqhkjO
+    PQIBBgUrgQQAIgNiAARGGPRUeASYE7ilcb59Lplt1HS21EktIc3WyUc3rVd17BZ+
+    OzVKUKlATQ8FZQ1Bcs5KFEQY+gDbSH/jmyA6LqNN1heIBh6vw9AoLQj/uMaocIAs
+    MkR2gWntT9zf2g8ysGWjggEmMIIBIjAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAww
+    CgYIKwYBBQUHAwMwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUH4c4aC1y99X3F+Oa
+    yiwx13lnwjgwHwYDVR0jBBgwFoAUyMUdAEGaJCkyUSTrDa5K7UoG0+wwgY0GCCsG
+    AQUFBwEBBIGAMH4wfAYIKwYBBQUHMAKGcGh0dHA6Ly9wcml2YXRlY2EtY29udGVu
+    dC02MDNmZTdlNy0wMDAwLTIyMjctYmY3NS1mNGY1ZTgwZDI5NTQuc3RvcmFnZS5n
+    b29nbGVhcGlzLmNvbS9jYTM2YTFlOTYyNDJiOWZjYjE0Ni9jYS5jcnQwHQYDVR0R
+    BBYwFIESbG9yZW5jLmRAZ21haWwuY29tMAoGCCqGSM49BAMDA2gAMGUCMQCsr95C
+    BNieKlQUj41RB9p4IB2c+8XbMK69jXm6IHZRca65nOP4nMwFUqlE1W/OnlACMAht
+    LTUlNndCw2IbG027fRqpElrc/IoIDBUa6aW7E1IL6gcnRk3MK38lkAg/jYaucw==
+    -----END CERTIFICATE-----


### PR DESCRIPTION
This PR adds some validation for the k8s manifests in the config directory and create a kind cluster to deploy the manifests and validate fulcio

this is just an initial work, more things can be added in the future

/assign @bobcallaway @dlorenc @lukehinds 


bob this is related to the PR opened https://github.com/sigstore/fulcio/pull/116
