### PR TITLE
change base image for fulcio-server when building with ko

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -60,3 +60,14 @@ jobs:
           kubectl wait --for=condition=Available --timeout=5m -n fulcio-dev deployment/fulcio-server
 
           kubectl get po -n fulcio-dev
+      - name: Collect logs
+        if: ${{ always() }}
+        run: |
+          mkdir -p /tmp/logs
+          kind export logs --name fulcio-cluster /tmp/logs
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: /tmp/logs

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -42,9 +42,10 @@ jobs:
           curl -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko && \
           chmod +x ./ko && sudo mv ko /usr/local/bin/
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         with:
           cluster_name: fulcio-cluster
+          wait: 300s
       - name: Deploy fulcio-dev
         run: |
           sed -i -e 's,memory: "1G",memory: "100m",g' ${{ github.workspace }}/config/deployment.yaml

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/base-debian10


### PR DESCRIPTION
Change the base image when building with `ko` this is needed because in this PR https://github.com/sigstore/fulcio/pull/115 we add some changes that require `CGO_ENABLED=1` and using the default base image we got some errors

Tested this with the changes in the PR above and it is working now.

- Also collect the cluster logs if we need to debug any issue

/assign @lukehinds @dlorenc 

Luke after we merge this you can rebase and then will work 😄 