### PR TITLE
Validate its a recognised CA

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -37,7 +37,7 @@ var serveCmd = &cobra.Command{
 	Long:  `Starts a http server and serves the configured api`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		if viper.GetString("ca") == "fulcioca" || viper.GetString("ca") != "googleca" {
+		if viper.GetString("ca") != "fulcioca" || viper.GetString("ca") != "googleca" {
 			log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
 		}
 

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -37,6 +37,10 @@ var serveCmd = &cobra.Command{
 	Long:  `Starts a http server and serves the configured api`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		if viper.GetString("ca") == "fulcioca" || viper.GetString("ca") != "googleca" {
+			log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
+		}
+
 		if viper.GetString("ca") == "googleca" && !viper.IsSet("gcp_private_ca_parent") {
 			panic("gcp_private_ca_parent must be set when using googleca")
 		}


### PR DESCRIPTION
I had a typo in fuclio serve -ca flag and spent hours trying to work
out why the CA backend was failing. The mispelt flag was being
captured in the middleware handler instead (ca.go line 65) with the
`genericCAError` from errors.go.

This will capture it before the server even starts and make it a
lot easier to see it's just a simple typo.

Signed-off-by: Luke Hinds <lhinds@redhat.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
