### PR TITLE
change or to and for known CA types

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -37,7 +37,7 @@ var serveCmd = &cobra.Command{
 	Long:  `Starts a http server and serves the configured api`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		if viper.GetString("ca") != "fulcioca" || viper.GetString("ca") != "googleca" {
+		if viper.GetString("ca") != "fulcioca" && viper.GetString("ca") != "googleca" {
 			log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
 		}
 


### PR DESCRIPTION
Signed-off-by: Thomas Runyon <runyontr@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->


Before the change the logic would fail:
```
go run main.go serve --ca googleca --gcp_private_ca_parent=projects/runyontr/locations/us-east1/ca/fulcio
2021-07-19T15:44:31.130-0400    INFO    app/serve.go:41 booya
2021-07-19T15:44:31.130-0400    FATAL   app/serve.go:42 unknown CA: googleca
github.com/sigstore/fulcio/cmd/app.glob..func2
        /Users/tom/go/src/github.com/runyontr/platform-one/big-bang/scratch/sigstore/fulcio/cmd/app/serve.go:42
github.com/spf13/cobra.(*Command).execute
        /Users/tom/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:860
github.com/spf13/cobra.(*Command).ExecuteC
        /Users/tom/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974
github.com/spf13/cobra.(*Command).Execute
        /Users/tom/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/sigstore/fulcio/cmd/app.Execute
        /Users/tom/go/src/github.com/runyontr/platform-one/big-bang/scratch/sigstore/fulcio/cmd/app/root.go:41
main.main
        /Users/tom/go/src/github.com/runyontr/platform-one/big-bang/scratch/sigstore/fulcio/main.go:21
runtime.main
        /usr/local/Cellar/go/1.16/libexec/src/runtime/proc.go:225
exit status 1
```

And now it starts up as expected:
```
❯ go run main.go serve --ca googleca --gcp_private_ca_parent=projects/leapfrogai/locations/us-east1/caPools/fulcio
2021-07-19T15:44:57.994-0400    INFO    config/config.go:78     No config at /etc/fulcio-config/config.json, using defaults: {map[https://accounts.google.com:{https://accounts.google.com sigstore email} https://oauth2.sigstore.dev/auth:{https://oauth2.sigstore.dev/auth sigstore email}]}
2021-07-19T15:44:58.374-0400    INFO    restapi/server.go:231   Serving fulcio server at http://127.0.0.1:51090
^C2021-07-19T15:45:05.940-0400  INFO    restapi/server.go:231   Shutting down... 
2021-07-19T15:45:05.940-0400    INFO    restapi/server.go:231   Stopped serving fulcio server at http://127.0.0.1:51090
```