### PR TITLE
Amend HSM cert usage

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -92,9 +92,8 @@ certificate authority for an instance of sigstore fulcio`,
 			NotBefore:             time.Now(),
 			NotAfter:              time.Now().AddDate(10, 0, 0),
 			IsCA:                  true,
-			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-			BasicConstraintsValid: true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			BasicConstraintsValid: true, MaxPathLen: 1,
 		}
 
 		caBytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, pubKey, privKey)


### PR DESCRIPTION
There was an issue with invalid key types when verifying
cosign signed registry sigs with a fulcio cert generated using
the fuclio createca command

This PR makes the resulting createca generated cert have partity
to GCA generated certs

The result is a HSM / createca root cert can be used to both sign
and verify registry entries

![image](https://user-images.githubusercontent.com/7058938/126965239-618f3b9a-f13b-4f59-91af-8562efeb3dd8.png)

Resolves: #150

Signed-off-by: Luke Hinds <lhinds@redhat.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
