### PR TITLE
Generate client code with swagger in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ SWAGGER := $(TOOLS_BIN_DIR)/swagger
 
 $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
 	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A fulcio_server --exclude-spec --flag-strategy=pflag -P github.com/coreos/go-oidc/v3/oidc.IDToken --additional-initialism=SCT
+	$(SWAGGER) generate client -f openapi.yaml -r COPYRIGHT.txt -t pkg/generated -P github.com/coreos/go-oidc/v3/oidc.IDToken
 
 # this exists to override pattern match rule above since this file is in the generated directory but should not be treated as generated code
 pkg/generated/restapi/configure_fulcio_server.go: $(OPENAPIDEPS)

--- a/pkg/generated/client/operations/signing_cert_responses.go
+++ b/pkg/generated/client/operations/signing_cert_responses.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
@@ -79,6 +80,13 @@ func NewSigningCertCreated() *SigningCertCreated {
 Generated Certificate Chain
 */
 type SigningCertCreated struct {
+
+	/* Signed Certificate Timestamp from Entry in CT Log
+
+	   Format: byte
+	*/
+	SCT strfmt.Base64
+
 	Payload string
 }
 
@@ -90,6 +98,17 @@ func (o *SigningCertCreated) GetPayload() string {
 }
 
 func (o *SigningCertCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// hydrates response header SCT
+	hdrSCT := response.GetHeader("SCT")
+
+	if hdrSCT != "" {
+		valsCT, err := formats.Parse("byte", hdrSCT)
+		if err != nil {
+			return errors.InvalidType("SCT", "header", "strfmt.Base64", hdrSCT)
+		}
+		o.SCT = *(valsCT.(*strfmt.Base64))
+	}
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {


### PR DESCRIPTION
This used to happen in sigstore/sigstore, but was removed in https://github.com/sigstore/sigstore/pull/103. Adding it back in here so that we can include the SCT in the client responses.

needed for https://github.com/sigstore/cosign/issues/591!

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
