### PR TITLE
Add support for Github OIDC

### DIFF
--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -107,6 +107,8 @@ func Subject(ctx context.Context, tok *oidc.IDToken, cfg config.FulcioConfig, pu
 		return challenges.Email(ctx, tok, publicKey, challenge)
 	case config.IssuerTypeSpiffe:
 		return challenges.Spiffe(ctx, tok, publicKey, challenge)
+	case config.IssuerTypeGithubWorkflow:
+		return challenges.GithubWorkflow(ctx, tok, publicKey, challenge)
 	default:
 		return nil, fmt.Errorf("unsupported issuer: %s", iss.Type)
 	}

--- a/pkg/api/googleca_signing_cert.go
+++ b/pkg/api/googleca_signing_cert.go
@@ -38,7 +38,8 @@ func GoogleCASigningCertHandler(ctx context.Context, subj *challenges.ChallengeR
 		privca = googleca.EmailSubject(subj.Value)
 	case challenges.SpiffeValue:
 		privca = googleca.SpiffeSubject(subj.Value)
-
+	case challenges.GithubWorkflowValue:
+		privca = googleca.GithubWorkflowSubject(subj.Value)
 	}
 	req := googleca.Req(parent, privca, publicKey)
 	log.Logger.Infof("requesting cert from %s for %v", parent, Subject)

--- a/pkg/ca/googleca/googleca.go
+++ b/pkg/ca/googleca/googleca.go
@@ -114,3 +114,11 @@ func SpiffeSubject(id string) *privatecapb.CertificateConfig_SubjectConfig {
 		},
 	}
 }
+
+func GithubWorkflowSubject(id string) *privatecapb.CertificateConfig_SubjectConfig {
+	return &privatecapb.CertificateConfig_SubjectConfig{
+		SubjectAltName: &privatecapb.SubjectAltNames{
+			Uris: []string{id},
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,8 +36,9 @@ type OIDCIssuer struct {
 type IssuerType string
 
 const (
-	IssuerTypeEmail  = "email"
-	IssuerTypeSpiffe = "spiffe"
+	IssuerTypeEmail          = "email"
+	IssuerTypeGithubWorkflow = "github-workflow"
+	IssuerTypeSpiffe         = "spiffe"
 )
 
 func ParseConfig(b []byte) (FulcioConfig, error) {
@@ -59,6 +60,11 @@ var DefaultConfig = FulcioConfig{
 			IssuerURL: "https://accounts.google.com",
 			ClientID:  "sigstore",
 			Type:      IssuerTypeEmail,
+		},
+		"https://vstoken.actions.githubusercontent.com": {
+			IssuerURL: "https://vstoken.actions.githubusercontent.com",
+			ClientID:  "sigstore",
+			Type:      IssuerTypeGithubWorkflow,
 		},
 	},
 }


### PR DESCRIPTION
This adds support for handing Github's OIDC tokens in addition to Google and SPIFFE.

Github OIDC tokens look something like:

```json
{
  "jti": "0687e989-80d6-42b0-a498-c65e99315f37",
  "sub": "repo:mattmoor/stupid-example:ref:refs/heads/main",
  "aud": "sigstore",
  "ref_protected": "false",
  "job_workflow_ref": "mattmoor/stupid-example/.github/workflows/my-action.yaml@refs/heads/main",
  "iss": "https://vstoken.actions.githubusercontent.com",
  "nbf": 1631210221,
  "exp": 1631211121,
  "iat": 1631210821
}
```

This change verifies things against the `iss` endpoint, and encodes the
`job_workflow_ref` into the x509 cert as a URI by prefixing it as:
```
https://github.com/{job_workflow_ref}
```
With the example:
```
https://github.com/mattmoor/stupid-example/.github/workflows/my-action.yaml@refs/heads/main
```


I verified this works** with a local Fulcio setup and some identity tokens I
exfiltrated from actions for the test.

** - The major caveat was that I had to tweak more than I'd have liked to for
my test because things currently use the v1beta1 API, and I had to rejigger
things to use v1 for my local test. I chatted a bunch with `@dlorenc` about
v1 migration, and the major concern is the backwards compatibility with
the current Fulcio cert, so these changes have those pieces backed out.

/assign @dlorenc 