### PR TITLE
add pkcs11-config-path command line parameter

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -46,7 +46,7 @@ such as organization, country etc. This can then be used as the root
 certificate authority for an instance of sigstore fulcio`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Logger.Info("binding to PKCS11 HSM")
-		p11Ctx, err := crypto11.ConfigureFromFile("config/crypto11.conf")
+		p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
 		if err != nil {
 			log.Logger.Fatal(err)
 		}

--- a/cmd/app/root.go
+++ b/cmd/app/root.go
@@ -51,6 +51,7 @@ func init() {
 	rootCmd.PersistentFlags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca fulcio)")
 	rootCmd.PersistentFlags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
 	rootCmd.PersistentFlags().String("config-path", "/etc/fulcio-config/config.json", "path to fulcio config json")
+	rootCmd.PersistentFlags().String("pkcs11-config-path", "config/crypto11.conf", "path to fulcio pkcs11 config file")
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Logger.Fatal(err)

--- a/pkg/pkcs11/pkcs11.go
+++ b/pkg/pkcs11/pkcs11.go
@@ -17,10 +17,11 @@ package pkcs11
 
 import (
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/spf13/viper"
 )
 
 func InitHSMCtx() (*crypto11.Context, error) {
-	p11Ctx, err := crypto11.ConfigureFromFile("config/crypto11.conf")
+	p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Allow to change crypto11.conf file location via `--pkcs11-config-path` command-line parameter

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->

No ticket

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* add pkcs11-config-path command line parameter to be able to change crypto11.conf file location
```
