### PR TITLE
use request ID logger where possible

### DIFF
--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -37,6 +37,7 @@ import (
 
 func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDToken) middleware.Responder {
 	ctx := params.HTTPRequest.Context()
+	logger := log.ContextLogger(ctx)
 
 	// none of the following cases should happen if the authentication path is working correctly; checking to be defensive
 	if principal == nil {
@@ -61,7 +62,7 @@ func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDT
 	case "googleca":
 		PemCertificate, PemCertificateChain, err = GoogleCASigningCertHandler(ctx, subj, publicKeyPEM)
 	case "pkcs11ca":
-		PemCertificate, PemCertificateChain, err = Pkcs11CASigningCertHandler(subj, publicKey)
+		PemCertificate, PemCertificateChain, err = Pkcs11CASigningCertHandler(ctx, subj, publicKey)
 	default:
 		return handleFulcioAPIError(params, http.StatusInternalServerError, err, genericCAError)
 	}
@@ -70,7 +71,7 @@ func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDT
 	}
 
 	// Submit to CTL
-	log.Logger.Info("Submitting CTL inclusion for OIDC grant: ", subj.Value)
+	logger.Info("Submitting CTL inclusion for OIDC grant: ", subj.Value)
 	var sctBytes []byte
 	ctURL := viper.GetString("ct-log-url")
 	if ctURL != "" {
@@ -83,8 +84,8 @@ func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDT
 		if err != nil {
 			return handleFulcioAPIError(params, http.StatusInternalServerError, err, failedToMarshalSCT)
 		}
-		log.Logger.Info("CTL Submission Signature Received: ", sct.Signature)
-		log.Logger.Info("CTL Submission ID Received: ", sct.ID)
+		logger.Info("CTL Submission Signature Received: ", sct.Signature)
+		logger.Info("CTL Submission ID Received: ", sct.ID)
 	} else {
 		log.Logger.Info("Skipping CT log upload.")
 	}

--- a/pkg/api/googleca_signing_cert.go
+++ b/pkg/api/googleca_signing_cert.go
@@ -28,6 +28,7 @@ import (
 )
 
 func GoogleCASigningCertHandler(ctx context.Context, subj *challenges.ChallengeResult, publicKey []byte) (string, []string, error) {
+	logger := log.ContextLogger(ctx)
 
 	parent := viper.GetString("gcp_private_ca_parent")
 
@@ -42,7 +43,7 @@ func GoogleCASigningCertHandler(ctx context.Context, subj *challenges.ChallengeR
 		privca = googleca.GithubWorkflowSubject(subj.Value)
 	}
 	req := googleca.Req(parent, privca, publicKey)
-	log.Logger.Infof("requesting cert from %s for %v", parent, Subject)
+	logger.Infof("requesting cert from %s for %v", parent, Subject)
 
 	resp, err := googleca.Client().CreateCertificate(ctx, req)
 	if err != nil {

--- a/pkg/api/pkcs11ca_signing_cert.go
+++ b/pkg/api/pkcs11ca_signing_cert.go
@@ -16,6 +16,7 @@
 package api
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"os"
@@ -28,7 +29,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Pkcs11CASigningCertHandler(subj *challenges.ChallengeResult, publicKey []byte) (string, []string, error) {
+func Pkcs11CASigningCertHandler(ctx context.Context, subj *challenges.ChallengeResult, publicKey []byte) (string, []string, error) {
+	logger := log.ContextLogger(ctx)
 
 	p11Ctx, err := pkcs11.InitHSMCtx()
 	if err != nil {
@@ -53,7 +55,7 @@ func Pkcs11CASigningCertHandler(subj *challenges.ChallengeResult, publicKey []by
 		}
 		block, _ := pem.Decode(pubPEMData)
 		if block == nil || block.Type != "CERTIFICATE" {
-			log.Logger.Fatal("failed to decode PEM block containing certificate")
+			logger.Fatal("failed to decode PEM block containing certificate")
 		}
 		rootCA, err = x509.ParseCertificate(block.Bytes)
 		if err != nil {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -69,9 +69,13 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 }
 
 func RequestIDLogger(r *http.Request) *zap.SugaredLogger {
+	return ContextLogger(r.Context())
+}
+
+func ContextLogger(ctx context.Context) *zap.SugaredLogger {
 	proposedLogger := Logger
-	if r != nil {
-		if ctxRequestID, ok := r.Context().Value(middleware.RequestIDKey).(string); ok {
+	if ctx != nil {
+		if ctxRequestID, ok := ctx.Value(middleware.RequestIDKey).(string); ok {
 			proposedLogger = proposedLogger.With(zap.String("requestID", ctxRequestID))
 		}
 	}


### PR DESCRIPTION
This gives each log message a request ID that allows for better correlation of message to specific HTTP transaction.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
