### PR TITLE
Add support for "meta issuers".

### DIFF
--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -43,6 +43,16 @@ data:
               "ClientID": "sigstore",
               "Type": "github-workflow"
             }
+          },
+          "MetaIssuers": {
+            "https://container.googleapis.com/v1/projects/*/locations/*/clusters/*": {
+              "ClientID": "sigstore",
+              "Type": "kubernetes"
+            },
+            "https://oidc.eks.*.amazonaws.com/id/*": {
+              "ClientID": "sigstore",
+              "Type": "kubernetes"
+            }
           }
         }
 kind: ConfigMap

--- a/federation/main.go
+++ b/federation/main.go
@@ -59,6 +59,18 @@ func main() {
 	}
 	fulcioConfig := &config.FulcioConfig{
 		OIDCIssuers: map[string]config.OIDCIssuer{},
+		MetaIssuers: map[string]config.OIDCIssuer{
+			// EKS Cluster OIDC issuers
+			"https://oidc.eks.*.amazonaws.com/id/*": {
+				ClientID: "sigstore",
+				Type:     "kubernetes",
+			},
+			// GKE Cluster OIDC issuers
+			"https://container.googleapis.com/v1/projects/*/locations/*/clusters/*": {
+				ClientID: "sigstore",
+				Type:     "kubernetes",
+			},
+		},
 	}
 	for _, m := range matches {
 		b, err := ioutil.ReadFile(m)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/golang-lru v0.5.3
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/miekg/pkcs11 v1.0.3 // indirect
 	github.com/mitchellh/mapstructure v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -499,6 +499,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,9 +31,66 @@ var validCfg = `
 			"IssuerURL": "https://accounts.google.com",
 			"ClientID": "foo"
 		}
+	},
+	"MetaIssuers": {
+		"https://oidc.eks.*.amazonaws.com/id/*": {
+			"ClientID": "bar"
+		}
 	}
 }
 `
+
+func TestMetaURLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		issuer  string
+		matches []string
+		misses  []string
+	}{{
+		name:   "AWS meta URL",
+		issuer: "https://oidc.eks.*.amazonaws.com/id/*",
+		matches: []string{
+			"https://oidc.eks.us-west-2.amazonaws.com/id/B02C93B6A2D30341AD01E1B6D48164CB",
+		},
+		misses: []string{
+			// Extra dots
+			"https://oidc.eks.us.west.2.amazonaws.com/id/B02C93B6A2D30341AD01E1B6D48164CB",
+			// Extra slashes
+			"https://oidc.eks.us-west/2.amazonaws.com/id/B02C93B6A2D3/0341AD01E1B6D48164CB",
+		},
+	}, {
+		name:   "GKE meta URL",
+		issuer: "https://container.googleapis.com/v1/projects/*/locations/*/clusters/*",
+		matches: []string{
+			"https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us-west1-b/clusters/tenant-cluster",
+		},
+		misses: []string{
+			// Extra dots
+			"https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us.west1.b/clusters/tenant-cluster",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			re, err := metaRegex(test.issuer)
+			if err != nil {
+				t.Errorf("metaRegex() = %v", err)
+			}
+
+			for _, match := range test.matches {
+				if !re.MatchString(match) {
+					t.Errorf("MatchString(%q) = false, wanted true", match)
+				}
+			}
+
+			for _, miss := range test.misses {
+				if re.MatchString(miss) {
+					t.Errorf("MatchString(%q) = true, wanted false", miss)
+				}
+			}
+		})
+	}
+}
 
 func TestLoad(t *testing.T) {
 	td := t.TempDir()
@@ -59,6 +116,17 @@ func TestLoad(t *testing.T) {
 	}
 	if got := len(cfg.OIDCIssuers); got != 1 {
 		t.Errorf("expected 1 issuer, got %d", got)
+	}
+
+	got, ok = cfg.GetIssuer("https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER")
+	if !ok {
+		t.Error("expected true, got false")
+	}
+	if got.ClientID != "bar" {
+		t.Errorf("expected bar, got %s", got.ClientID)
+	}
+	if got.IssuerURL != "https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER" {
+		t.Errorf("expected https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER, got %s", got.IssuerURL)
 	}
 }
 


### PR DESCRIPTION
These are separate from the fixed OIDC issuers, and they represent templates for *classes* of OIDC endpoints that we want to support, e.g. for EKS:
```
https://oidc.eks.*.amazonaws.com/id/*
```

The `*` character here will be used to match `[a-zA-Z0-9_-]+`, so no host or path delimiting characters are allowed to prevent attacks like:

```
https://oidc.eks.mattmoor.io/pwned.amazonaws.com/id/does-not-matter
```

We do NOT maintain OIDC verifiers for all of the possible endpoints, but we do keep an LRU cache to avoid the expensive discovery process on each request.

Related: https://github.com/sigstore/fulcio/issues/212
Signed-off-by: Matt Moore <mattomata@gmail.com>

WIP until https://github.com/sigstore/fulcio/pull/222 lands, and I may add the GKE/EKS stuff to this change.

#### Release Note

```release-note
Fulcio's config now supports "MetaIssuer" blocks where the Issuer URL keys may use wildcards for host or path components.
```
