### PR TITLE
Add support for recoginizing allow.pub as an spiffe issuer

### DIFF
--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -22,6 +22,11 @@ data:
               "ClientID": "sigstore",
               "Type": "email"
             },
+            "https://allow.pub": {
+              "IssuerURL": "https://allow.pub",
+              "ClientID": "sigstore",
+              "Type": "spiffe"
+            },
             "https://oauth2.sigstore.dev/auth": {
               "IssuerURL": "https://oauth2.sigstore.dev/auth",
               "ClientID": "sigstore",

--- a/federation/external/allow.pub/config.yaml
+++ b/federation/external/allow.pub/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: https://allow.pub
+contact: evan@phx.io
+description: "Server side signing support for the OCI registry vcr.pub"
+type: "spiffe"


### PR DESCRIPTION
#### Summary

Add support for fulcio to allow spiffe tokens signed by allow.pub

#### Description

I'm building an OCI registry that would like to perform server side
cosign support via fulcio. The OCI registry is called vcr.pub and should
be available in beta form soon.

The reason that the domain used here is allow.pub rather than vcr.pub is
one of the future services we'd like to support is other OIDC related
authentication tasks, so we've separated it from the OCI registry off
the bat.