### PR TITLE
Add commit sha and trigger to github workflow

### DIFF
--- a/config/config.jsn
+++ b/config/config.jsn
@@ -20,6 +20,11 @@
       "IssuerURL": "https://oidc.dlorenc.dev",
       "ClientID": "sigstore",
       "Type": "spiffe"
-    }
+    },
+    "https://token.actions.githubusercontent.com": {
+              "IssuerURL": "https://token.actions.githubusercontent.com",
+              "ClientID": "sigstore",
+              "Type": "github-workflow"
+            }
   }
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

draft for https://github.com/sigstore/fulcio/issues/208
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

* Adds commit sha and trigger (event_name) associated with the github workflow in OID extensions 1.3.6.1.4.1.57264.1.(2/3). 
* Tested this with a id token I grabbed from a workflow, see below: (trigger workflow_dispatch)
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            b5:ca:cd:df:e0:98:eb:38:80:f0:40:f6:97:bc:3d:49:93:b0:04
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: O = sigstore.dev, CN = sigstore
        Validity
            Not Before: Nov  3 15:33:38 2021 GMT
            Not After : Nov  3 15:53:37 2021 GMT
        Subject: 
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:af:5a:ee:69:1e:e4:d3:03:b1:0c:c9:8c:f0:12:
                    04:0f:62:75:36:d7:f9:c0:7e:a4:bb:b2:57:64:03:
                    a7:fd:0c:f3:7a:95:4f:2a:a2:33:98:c1:e5:61:e5:
                    94:45:b2:64:46:a3:fc:29:5b:43:b8:91:08:92:4f:
                    42:1d:a6:c4:17
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage: 
                Code Signing
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Subject Key Identifier: 
                67:A7:68:82:FA:C3:69:C9:DE:7D:5F:75:9E:1D:36:96:19:C4:3E:1D
            X509v3 Authority Key Identifier: 
                keyid:C8:C5:1D:00:41:9A:24:29:32:51:24:EB:0D:AE:4A:ED:4A:06:D3:EC

            Authority Information Access: 
                CA Issuers - URI:http://privateca-content-603fe7e7-0000-2227-bf75-f4f5e80d2954.storage.googleapis.com/ca36a1e96242b9fcb146/ca.crt

            X509v3 Subject Alternative Name: critical
                URI:https://github.com/asraa/test-sigstore-root/.github/workflows/snapshot-timestamp.yml@refs/heads/main
            1.3.6.1.4.1.57264.1.1: 
                https://token.actions.githubusercontent.com
            1.3.6.1.4.1.57264.1.2: 
                508c7985fb3bbcc201d4a4c57fb29e565dad48b8
            1.3.6.1.4.1.57264.1.3: 
                workflow_dispatch
    Signature Algorithm: ecdsa-with-SHA384
         30:66:02:31:00:b6:68:a9:cb:59:26:2c:1d:00:11:45:40:da:
         38:03:d5:da:25:1e:00:ad:f4:14:bc:24:00:70:20:32:86:ce:
         d3:fe:94:36:fc:58:d4:c2:81:4a:39:41:56:36:a4:2c:e9:02:
         31:00:ef:a8:6f:a0:41:06:eb:9b:12:10:a8:20:34:40:6a:39:
         70:f0:9c:a5:87:ab:86:f7:7a:23:fd:7c:f0:e0:d3:12:74:4a:
         55:e7:50:7a:df:f9:47:a2:cc:3b:e0:4c:94:46
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
