### PR TITLE
plumb through !cgo golang tags that removes pkcs11 support

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,9 +3,7 @@ builds:
 - main: .
   env:
   - CGO_ENABLED=1
-# If you are deploying from M1, you can use this (uncomment this, and
-# comment above), though it does remove the support for the "createca" command.
+# If you are deploying from M1, you can use this (uncomment below, and
+# comment out above), though it does remove the support for the "createca" command.
 # But at least you can deploy it from M1 using this.
-#- main: .
-#  flags:
-#  - -tags=purego
+#  - CGO_ENABLED=0

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,3 +3,9 @@ builds:
 - main: .
   env:
   - CGO_ENABLED=1
+# If you are deploying from M1, you can use this (uncomment this, and
+# comment above), though it does remove the support for the "createca" command.
+# But at least you can deploy it from M1 using this.
+#- main: .
+#  flags:
+#  - -tags=purego

--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -1,3 +1,6 @@
+//go:build !purego
+// +build !purego
+
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +151,7 @@ certificate authority for an instance of sigstore fulcio`,
 
 func init() {
 	rootCmd.AddCommand(createcaCmd)
-	createcaCmd.PersistentFlags().String("org", "Fuclio Root CA", "Organization name for root CA")
+	createcaCmd.PersistentFlags().String("org", "Fulcio Root CA", "Organization name for root CA")
 	createcaCmd.PersistentFlags().String("country", "", "Country name for root CA")
 	createcaCmd.PersistentFlags().String("province", "", "Province name for root CA")
 	createcaCmd.PersistentFlags().String("locality", "", "Locality name for root CA")

--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -1,5 +1,5 @@
-//go:build !purego
-// +build !purego
+//go:build cgo
+// +build cgo
 
 // Copyright 2021 The Sigstore Authors.
 //

--- a/config/DEVELOPMENT.md
+++ b/config/DEVELOPMENT.md
@@ -1,7 +1,10 @@
 # Developing Fulcio
 
 Fulcio uses Go and can be run with no other dependencies, other than a trust root PKIX / CA capable system.  Currently
-fulcio supports Google certificate authority service (GCP SA)  or a PKCS11 capable HSM (such as SoftHSM).
+fulcio supports Google certificate authority service (GCP SA) or a PKCS11 capable HSM (such as SoftHSM). PKCS11 support requires C libraries which can cause some issues in
+some cases (like building on Mac M1), and if you do not require it, you can
+disable support for it using golang tags `-tags=purego` when building. **NOTE**
+This removes the support for `createca` command from the resulting binary.
 
 ## GCP SA configuration
 

--- a/config/DEVELOPMENT.md
+++ b/config/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 Fulcio uses Go and can be run with no other dependencies, other than a trust root PKIX / CA capable system.  Currently
 fulcio supports Google certificate authority service (GCP SA) or a PKCS11 capable HSM (such as SoftHSM). PKCS11 support requires C libraries which can cause some issues in
 some cases (like building on Mac M1), and if you do not require it, you can
-disable support for it using golang tags `-tags=purego` when building. **NOTE**
+disable support for it by specifying `CGO_ENABLED=0` when building. **NOTE**
 This removes the support for `createca` command from the resulting binary.
 
 ## GCP SA configuration

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -1,0 +1,118 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package x509ca
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sigstore/fulcio/pkg/ca"
+	"github.com/sigstore/fulcio/pkg/challenges"
+)
+
+type X509CA struct {
+	RootCA  *x509.Certificate
+	PrivKey crypto.Signer
+}
+
+func (x *X509CA) CreateCertificate(_ context.Context, subject *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
+	return x.CreateCertificateWithCA(x, subject)
+}
+
+func (x *X509CA) CreateCertificateWithCA(certauth *X509CA, subject *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
+	// TODO: Track / increment serial nums instead, although unlikely we will create dupes, it could happen
+	uuid := uuid.New()
+	var serialNumber big.Int
+	serialNumber.SetBytes(uuid[:])
+
+	cert := &x509.Certificate{
+		SerialNumber: &serialNumber,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Minute * 10),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	switch subject.TypeVal {
+	case challenges.EmailValue:
+		cert.EmailAddresses = []string{subject.Value}
+	case challenges.SpiffeValue:
+		challengeURL, err := url.Parse(subject.Value)
+		if err != nil {
+			return nil, ca.ValidationError(err)
+		}
+		cert.URIs = []*url.URL{challengeURL}
+	case challenges.GithubWorkflowValue:
+		jobWorkflowURI, err := url.Parse(subject.Value)
+		if err != nil {
+			return nil, ca.ValidationError(err)
+		}
+		cert.URIs = []*url.URL{jobWorkflowURI}
+	case challenges.KubernetesValue:
+		k8sURI, err := url.Parse(subject.Value)
+		if err != nil {
+			return nil, ca.ValidationError(err)
+		}
+		cert.URIs = []*url.URL{k8sURI}
+	}
+	cert.ExtraExtensions = append(IssuerExtension(subject.Issuer), AdditionalExtensions(subject)...)
+
+	finalCertBytes, err := x509.CreateCertificate(rand.Reader, cert, certauth.RootCA, subject.PublicKey, certauth.PrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return ca.CreateCSCFromDER(subject, finalCertBytes, nil)
+}
+
+func AdditionalExtensions(subject *challenges.ChallengeResult) []pkix.Extension {
+	res := []pkix.Extension{}
+	if subject.TypeVal == challenges.GithubWorkflowValue {
+		if trigger, ok := subject.AdditionalInfo[challenges.GithubWorkflowTrigger]; ok {
+			res = append(res, pkix.Extension{
+				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 2},
+				Value: []byte(trigger),
+			})
+		}
+
+		if sha, ok := subject.AdditionalInfo[challenges.GithubWorkflowSha]; ok {
+			res = append(res, pkix.Extension{
+				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 3},
+				Value: []byte(sha),
+			})
+		}
+	}
+	return res
+}
+
+func IssuerExtension(issuer string) []pkix.Extension {
+	if issuer == "" {
+		return nil
+	}
+
+	return []pkix.Extension{{
+		Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
+		Value: []byte(issuer),
+	}}
+}

--- a/pkg/ca/x509ca/x509ca.go
+++ b/pkg/ca/x509ca/x509ca.go
@@ -1,5 +1,5 @@
-//go:build !purego
-// +build !purego
+//go:build cgo
+// +build cgo
 
 // Copyright 2021 The Sigstore Authors.
 //

--- a/pkg/ca/x509ca/x509ca.go
+++ b/pkg/ca/x509ca/x509ca.go
@@ -1,3 +1,6 @@
+//go:build !purego
+// +build !purego
+
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,31 +19,15 @@
 package x509ca
 
 import (
-	"context"
-	"crypto"
-	"crypto/rand"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/pem"
 	"errors"
-	"math/big"
-	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/challenges"
 	"github.com/sigstore/fulcio/pkg/pkcs11"
 	"github.com/spf13/viper"
 )
-
-type X509CA struct {
-	RootCA  *x509.Certificate
-	PrivKey crypto.Signer
-}
 
 func NewX509CA() (*X509CA, error) {
 	ca := &X509CA{}
@@ -82,85 +69,4 @@ func NewX509CA() (*X509CA, error) {
 
 	return ca, nil
 
-}
-
-func (x *X509CA) CreateCertificate(_ context.Context, subject *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
-	return x.CreateCertificateWithCA(x, subject)
-}
-
-func (x *X509CA) CreateCertificateWithCA(certauth *X509CA, subject *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
-	// TODO: Track / increment serial nums instead, although unlikely we will create dupes, it could happen
-	uuid := uuid.New()
-	var serialNumber big.Int
-	serialNumber.SetBytes(uuid[:])
-
-	cert := &x509.Certificate{
-		SerialNumber: &serialNumber,
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(time.Minute * 10),
-		SubjectKeyId: []byte{1, 2, 3, 4, 6},
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
-		KeyUsage:     x509.KeyUsageCertSign,
-	}
-	switch subject.TypeVal {
-	case challenges.EmailValue:
-		cert.EmailAddresses = []string{subject.Value}
-	case challenges.SpiffeValue:
-		challengeURL, err := url.Parse(subject.Value)
-		if err != nil {
-			return nil, ca.ValidationError(err)
-		}
-		cert.URIs = []*url.URL{challengeURL}
-	case challenges.GithubWorkflowValue:
-		jobWorkflowURI, err := url.Parse(subject.Value)
-		if err != nil {
-			return nil, ca.ValidationError(err)
-		}
-		cert.URIs = []*url.URL{jobWorkflowURI}
-	case challenges.KubernetesValue:
-		k8sURI, err := url.Parse(subject.Value)
-		if err != nil {
-			return nil, ca.ValidationError(err)
-		}
-		cert.URIs = []*url.URL{k8sURI}
-	}
-	cert.ExtraExtensions = append(IssuerExtension(subject.Issuer), AdditionalExtensions(subject)...)
-
-	finalCertBytes, err := x509.CreateCertificate(rand.Reader, cert, certauth.RootCA, subject.PublicKey, certauth.PrivKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return ca.CreateCSCFromDER(subject, finalCertBytes, nil)
-}
-
-func AdditionalExtensions(subject *challenges.ChallengeResult) []pkix.Extension {
-	res := []pkix.Extension{}
-	if subject.TypeVal == challenges.GithubWorkflowValue {
-		if trigger, ok := subject.AdditionalInfo[challenges.GithubWorkflowTrigger]; ok {
-			res = append(res, pkix.Extension{
-				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 2},
-				Value: []byte(trigger),
-			})
-		}
-
-		if sha, ok := subject.AdditionalInfo[challenges.GithubWorkflowSha]; ok {
-			res = append(res, pkix.Extension{
-				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 3},
-				Value: []byte(sha),
-			})
-		}
-	}
-	return res
-}
-
-func IssuerExtension(issuer string) []pkix.Extension {
-	if issuer == "" {
-		return nil
-	}
-
-	return []pkix.Extension{{
-		Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
-		Value: []byte(issuer),
-	}}
 }

--- a/pkg/ca/x509ca/x509canocgo.go
+++ b/pkg/ca/x509ca/x509canocgo.go
@@ -1,5 +1,5 @@
-//go:build purego
-// +build purego
+//go:build !cgo
+// +build !cgo
 
 // Copyright 2021 The Sigstore Authors.
 //
@@ -25,5 +25,5 @@ import (
 // NewX509CA is a placeholder for erroring with a meaningful message if the
 // binary has been built with purego tags.
 func NewX509CA() (*X509CA, error) {
-	return nil, errors.New("binary has been built with purego tags, PKCS11 not supported")
+	return nil, errors.New("binary has been built with no cgo support, PKCS11 not supported")
 }

--- a/pkg/ca/x509ca/x509capurego.go
+++ b/pkg/ca/x509ca/x509capurego.go
@@ -1,5 +1,5 @@
-//go:build !purego
-// +build !purego
+//go:build purego
+// +build purego
 
 // Copyright 2021 The Sigstore Authors.
 //
@@ -16,17 +16,14 @@
 // limitations under the License.
 //
 
-package pkcs11
+package x509ca
 
 import (
-	"github.com/ThalesIgnite/crypto11"
-	"github.com/spf13/viper"
+	"errors"
 )
 
-func InitHSMCtx() (*crypto11.Context, error) {
-	p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
-	if err != nil {
-		return nil, err
-	}
-	return p11Ctx, nil
+// NewX509CA is a placeholder for erroring with a meaningful message if the
+// binary has been built with purego tags.
+func NewX509CA() (*X509CA, error) {
+	return nil, errors.New("binary has been built with purego tags, PKCS11 not supported")
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
If specifying golang env `CGO_ENABLED=0`, remove the code that uses PKCS11, because it depends on C. By default, nothing changes, this is just purely an option you must specify.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #240 


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
 * Make it possible to build the binary in pure go mode by specifying `CGO_ENABLED=0`. Because pkcs11 support requires C support, when specifying this option, it does remove the support for `createca` command.
 * Fixes #240 
```
