### PR TITLE
Thread `FulcioConfig` through from main via `ctx`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ SERVER_LDFLAGS="-X $(SERVER_PKG).gitVersion=$(GIT_VERSION) -X $(SERVER_PKG).gitC
 SWAGGER := $(TOOLS_BIN_DIR)/swagger
 
 $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
-	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A fulcio_server --exclude-spec --flag-strategy=pflag -P github.com/coreos/go-oidc/v3/oidc.IDToken --additional-initialism=SCT
-	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated -P github.com/coreos/go-oidc/v3/oidc.IDToken
+	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A fulcio_server --exclude-spec --flag-strategy=pflag --principal github.com/coreos/go-oidc/v3/oidc.IDToken --additional-initialism=SCT
+	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --principal github.com/coreos/go-oidc/v3/oidc.IDToken
 
 # this exists to override pattern match rule above since this file is in the generated directory but should not be treated as generated code
 pkg/generated/restapi/configure_fulcio_server.go: $(OPENAPIDEPS)

--- a/cmd/app/root.go
+++ b/cmd/app/root.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,8 +38,8 @@ var rootCmd = &cobra.Command{
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+func Execute(ctx context.Context) {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		log.Logger.Error(err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -15,8 +15,12 @@
 
 package main
 
-import "github.com/sigstore/fulcio/cmd/app"
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/cmd/app"
+)
 
 func main() {
-	app.Execute()
+	app.Execute(context.Background())
 }

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -160,8 +160,7 @@ func SigningCertHandler(params operations.SigningCertParams, principal *oidc.IDT
 }
 
 func ExtractSubject(ctx context.Context, tok *oidc.IDToken, publicKey crypto.PublicKey, challenge []byte) (*challenges.ChallengeResult, error) {
-	cfg := config.Config()
-	iss, ok := cfg.GetIssuer(tok.Issuer)
+	iss, ok := config.FromContext(ctx).GetIssuer(tok.Issuer)
 	if !ok {
 		return nil, fmt.Errorf("configuration can not be loaded for issuer %v", tok.Issuer)
 	}

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -79,8 +79,7 @@ func Email(ctx context.Context, principal *oidc.IDToken, pubKey crypto.PublicKey
 		return nil, err
 	}
 
-	globalCfg := config.Config()
-	cfg, ok := globalCfg.GetIssuer(principal.Issuer)
+	cfg, ok := config.FromContext(ctx).GetIssuer(principal.Issuer)
 	if !ok {
 		return nil, errors.New("invalid configuration for OIDC ID Token issuer")
 	}
@@ -103,8 +102,7 @@ func Spiffe(ctx context.Context, principal *oidc.IDToken, pubKey crypto.PublicKe
 
 	spiffeID := principal.Subject
 
-	globalCfg := config.Config()
-	cfg, ok := globalCfg.GetIssuer(principal.Issuer)
+	cfg, ok := config.FromContext(ctx).GetIssuer(principal.Issuer)
 	if !ok {
 		return nil, errors.New("invalid configuration for OIDC ID Token issuer")
 	}
@@ -150,8 +148,7 @@ func Kubernetes(ctx context.Context, principal *oidc.IDToken, pubKey crypto.Publ
 		return nil, err
 	}
 
-	globalCfg := config.Config()
-	cfg, ok := globalCfg.GetIssuer(principal.Issuer)
+	cfg, ok := config.FromContext(ctx).GetIssuer(principal.Issuer)
 	if !ok {
 		return nil, errors.New("invalid configuration for OIDC ID Token issuer")
 	}
@@ -185,8 +182,7 @@ func GithubWorkflow(ctx context.Context, principal *oidc.IDToken, pubKey crypto.
 		return nil, err
 	}
 
-	globalCfg := config.Config()
-	cfg, ok := globalCfg.GetIssuer(principal.Issuer)
+	cfg, ok := config.FromContext(ctx).GetIssuer(principal.Issuer)
 	if !ok {
 		return nil, errors.New("invalid configuration for OIDC ID Token issuer")
 	}


### PR DESCRIPTION
Thread `FulcioConfig` through to handlers via `ctx` based on a value that's explicitly `Load()`ed at application start.  This is the first of what I expect will be a bunch of refactoring PRs for Fulcio, but I'm trying to take them in bite-sized chunks.  This change:
1. Plumbs through `ctx` as a way we can pass configuration downstream to handlers (here with `FulcioConfig`, but I'd like to kill the usage of `viper` in our library code)
2. Enables us to start reloading `FulcioConfig` (and eventually others!) periodically (or even via an informer!) to avoid needing to cycle pods to force config reloads.

There are some other auxiliary benefits to passing `ctx` like enabling us to model the K8s lifecycle properly by "draining" pods on `SIGTERM`, which I'm not sure we properly handle today (would require us to switch to something like `knative.dev/pkg/signals.NewContext`).

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

```release-note
NONE
```
