### PR TITLE
Consolidate `viper` usage in `pkg/ca/ca.go`

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -68,7 +68,7 @@ var serveCmd = &cobra.Command{
 			}
 		}()
 
-		cfg, err := config.Load()
+		cfg, err := config.Load(viper.GetString("config-path"))
 		if err != nil {
 			log.Logger.Fatalf("error loading config: %v", err)
 		}

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -56,14 +56,22 @@ func CA() certauth.CertificateAuthority {
 			version := viper.GetString("gcp_private_ca_version")
 			switch version {
 			case "v1":
-				ca, err = googlecav1.NewCertAuthorityService()
+				ca, err = googlecav1.NewCertAuthorityService(viper.GetString("gcp_private_ca_parent"))
 			case "v1beta1":
-				ca, err = googlecav1beta1.NewCertAuthorityService()
+				ca, err = googlecav1beta1.NewCertAuthorityService(viper.GetString("gcp_private_ca_parent"))
 			default:
 				err = fmt.Errorf("invalid value for gcp_private_ca_version: %v", version)
 			}
 		case "pkcs11ca":
-			ca, err = x509ca.NewX509CA()
+			params := x509ca.Params{
+				ConfigPath: viper.GetString("pkcs11-config-path"),
+				RootID:     viper.GetString("hsm-caroot-id"),
+			}
+			if viper.IsSet("aws-hsm-root-ca-path") {
+				path := viper.GetString("aws-hsm-root-ca-path")
+				params.CAPath = &path
+			}
+			ca, err = x509ca.NewX509CA(params)
 		case "ephemeralca":
 			ca, err = ephemeralca.NewEphemeralCA()
 		default:

--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sigstore/fulcio/pkg/challenges"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"github.com/spf13/viper"
 	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -45,9 +44,9 @@ type CertAuthorityService struct {
 	client *privateca.CertificateAuthorityClient
 }
 
-func NewCertAuthorityService() (*CertAuthorityService, error) {
+func NewCertAuthorityService(parent string) (*CertAuthorityService, error) {
 	cas := &CertAuthorityService{
-		parent: viper.GetString("gcp_private_ca_parent"),
+		parent: parent,
 	}
 	var err error
 	cas.client, err = casClient()

--- a/pkg/ca/googleca/v1beta1/googleca.go
+++ b/pkg/ca/googleca/v1beta1/googleca.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sigstore/fulcio/pkg/challenges"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"github.com/spf13/viper"
 	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1beta1"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -45,9 +44,9 @@ type CertAuthorityService struct {
 	client *privateca.CertificateAuthorityClient
 }
 
-func NewCertAuthorityService() (*CertAuthorityService, error) {
+func NewCertAuthorityService(parent string) (*CertAuthorityService, error) {
 	cas := &CertAuthorityService{
-		parent: viper.GetString("gcp_private_ca_parent"),
+		parent: parent,
 	}
 	var err error
 	cas.client, err = casClient()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sigstore/fulcio/pkg/log"
-	"github.com/spf13/viper"
 )
 
 type FulcioConfig struct {
@@ -175,10 +174,6 @@ var originalTransport = http.DefaultTransport
 
 type configKey struct{}
 
-func Load() (*FulcioConfig, error) {
-	return load(viper.GetString("config-path"))
-}
-
 func With(ctx context.Context, cfg *FulcioConfig) context.Context {
 	ctx = context.WithValue(ctx, configKey{}, cfg)
 	return ctx
@@ -193,7 +188,7 @@ func FromContext(ctx context.Context) *FulcioConfig {
 }
 
 // Load a config from disk, or use defaults
-func load(configPath string) (*FulcioConfig, error) {
+func Load(configPath string) (*FulcioConfig, error) {
 	var config *FulcioConfig
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		log.Logger.Infof("No config at %s, using defaults: %v", configPath, DefaultConfig)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/spf13/viper"
 )
 
 var validCfg = `
@@ -100,9 +99,8 @@ func TestLoad(t *testing.T) {
 	if err := ioutil.WriteFile(cfgPath, []byte(validCfg), 0644); err != nil {
 		t.Fatal(err)
 	}
-	viper.GetViper().Set("config-path", cfgPath)
 
-	cfg, _ := Load()
+	cfg, _ := Load(cfgPath)
 	got, ok := cfg.GetIssuer("https://accounts.google.com")
 	if !ok {
 		t.Error("expected true, got false")
@@ -138,7 +136,7 @@ func TestLoadDefaults(t *testing.T) {
 
 	// Don't put anything here!
 	cfgPath := filepath.Join(td, "config.json")
-	cfg, err := load(cfgPath)
+	cfg, err := Load(cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pkcs11/pkcs11.go
+++ b/pkg/pkcs11/pkcs11.go
@@ -20,11 +20,10 @@ package pkcs11
 
 import (
 	"github.com/ThalesIgnite/crypto11"
-	"github.com/spf13/viper"
 )
 
-func InitHSMCtx() (*crypto11.Context, error) {
-	p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
+func InitHSMCtx(configPath string) (*crypto11.Context, error) {
+	p11Ctx, err := crypto11.ConfigureFromFile(configPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using `viper` (like flags, logging) insider of libraries is a bit of a code smell, so I started to look at where we were using viper directly, and started threading particular bits of configuration through as params, which seems to be the most natural way to do this in most contexts.

Right now there is still a big wad of usage in `pkg/ca/ca.go` (almost entirely in `CA()`), which I'm going to start looking into next, but at least the remainder have been eliminated. 💥 

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
