### PR TITLE
Drop gratuitous `sync.Once` in google CAs.

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -85,9 +85,9 @@ var serveCmd = &cobra.Command{
 			version := viper.GetString("gcp_private_ca_version")
 			switch version {
 			case "v1":
-				baseca, err = googlecav1.NewCertAuthorityService(viper.GetString("gcp_private_ca_parent"))
+				baseca, err = googlecav1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
 			case "v1beta1":
-				baseca, err = googlecav1beta1.NewCertAuthorityService(viper.GetString("gcp_private_ca_parent"))
+				baseca, err = googlecav1beta1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
 			default:
 				err = fmt.Errorf("invalid value for gcp_private_ca_version: %v", version)
 			}

--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"sync"
 
 	privateca "cloud.google.com/go/security/privateca/apiv1"
 	"github.com/sigstore/fulcio/pkg/ca"
@@ -33,36 +32,20 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-var (
-	once sync.Once
-	c    *privateca.CertificateAuthorityClient
-	cErr error
-)
-
 type CertAuthorityService struct {
 	parent string
 	client *privateca.CertificateAuthorityClient
 }
 
-func NewCertAuthorityService(parent string) (*CertAuthorityService, error) {
-	cas := &CertAuthorityService{
-		parent: parent,
-	}
-	var err error
-	cas.client, err = casClient()
+func NewCertAuthorityService(ctx context.Context, parent string) (*CertAuthorityService, error) {
+	client, err := privateca.NewCertificateAuthorityClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return cas, nil
-}
-
-func casClient() (*privateca.CertificateAuthorityClient, error) {
-	// Use a once block to avoid creating a new client every time.
-	once.Do(func() {
-		c, cErr = privateca.NewCertificateAuthorityClient(context.Background())
-	})
-
-	return c, cErr
+	return &CertAuthorityService{
+		parent: parent,
+		client: client,
+	}, nil
 }
 
 // getPubKeyFormat Returns the PublicKey KeyFormat required by gcp privateca.


### PR DESCRIPTION
This threads `cmd.Context()` into the constructor, and has it call the client constructor directly.  Previously the caller was already wrapped in a `sync.Once`, but not this is all called once from the command's `Run` method.

WIP until https://github.com/sigstore/fulcio/pull/257 merges.

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
