### PR TITLE
Wrap the server with the Prometheus so we get metrics + add an e2e te…

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -140,6 +140,9 @@ jobs:
           sed -i -e 's,--ca=googleca,--ca=ephemeralca,g' ${{ github.workspace }}/config/deployment.yaml
           # Drop the ct-log flag's value to elide CT-log uploads.
           sed -i -E 's,"--ct-log-url=[^"]+","--ct-log-url=",g' ${{ github.workspace }}/config/deployment.yaml
+          # Switch to one replica to make it easier to test the scraping of
+          # metrics since we know all the requests then go to the same server.
+          sed -i -E 's,replicas: 3,replicas: 1,g' ${{ github.workspace }}/config/deployment.yaml
 
           # From: https://banzaicloud.com/blog/kubernetes-oidc/
           # To be able to fetch the public keys and validate the JWT tokens against

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -225,6 +225,25 @@ jobs:
 
           kubectl wait --for=condition=Complete --timeout=90s job/check-oidc
 
+      - name: Validate prometheus metrics exported and look correct
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: check-prometheus-metrics
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                automountServiceAccountToken: false
+                containers:
+                - name: check-metrics
+                  image: ko://github.com/sigstore/fulcio/test/prometheus/
+          EOF
+
+          kubectl wait --for=condition=Complete --timeout=90s job/check-prometheus-metrics
+
       - name: Collect logs
         if: ${{ always() }}
         run: |

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -143,6 +143,14 @@ jobs:
           # Switch to one replica to make it easier to test the scraping of
           # metrics since we know all the requests then go to the same server.
           sed -i -E 's,replicas: 3,replicas: 1,g' ${{ github.workspace }}/config/deployment.yaml
+          # Expose the prometheus port as a service so tests can grab it
+          # without hitting the k8s API
+          cat <<EOF >> ${{ github.workspace }}/config/deployment.yaml
+              - name: prometheus
+                protocol: TCP
+                port: 2112
+                targetPort: 2112
+          EOF
 
           # From: https://banzaicloud.com/blog/kubernetes-oidc/
           # To be able to fetch the public keys and validate the JWT tokens against

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Validate prometheus metrics exported and look correct
         run: |
-          cat <<EOF | kubectl apply -f -
+          cat <<EOF | ko apply -f -
           apiVersion: batch/v1
           kind: Job
           metadata:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are other targets available in the [`Makefile`](Makefile), check it out.
 
 ## API
 
-The API is defined via OpenAPI, defined [here](openapi.yaml).
+The API is defined [here](./pkg/api/client.go).
 
 ## Transparency
 

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: fulcio-server
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: fulcio-server

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -89,7 +89,3 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 5555
-    - name: prometheus
-      protocol: TCP
-      port: 2112
-      targetPort: 2112

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: fulcio-server
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: fulcio-server

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -85,6 +85,11 @@ spec:
     app: fulcio-server
   type: LoadBalancer
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 5555
+    - name: prometheus
+      protocol: TCP
+      port: 2112
+      targetPort: 2112

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,8 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/prometheus/common v0.29.0 // indirect
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.29.0
 	github.com/prometheus/procfs v0.7.0 // indirect
 	github.com/sigstore/sigstore v1.0.1
 	github.com/spf13/cobra v1.2.1

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -38,7 +38,7 @@ const SigstorePublicServerURL = "https://fulcio.sigstore.dev"
 
 // Client is the interface for accessing the Fulcio API.
 type Client interface {
-	// SigningCert sends the provided CertificateRequest to the /api/v1/singingCert
+	// SigningCert sends the provided CertificateRequest to the /api/v1/signingCert
 	// endpoint of a Fulcio API, authenticated with the provided bearer token.
 	SigningCert(cr CertificateRequest, token string) (*CertificateResponse, error)
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -29,5 +29,5 @@ var (
 	MetricLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "fulcio_api_latency",
 		Help: "API Latency on calls",
-	}, []string{"path", "code"})
+	}, []string{"code", "method"})
 )

--- a/test/prometheus/main.go
+++ b/test/prometheus/main.go
@@ -32,7 +32,7 @@ func fatal(err error) {
 }
 
 func parseMF(url string) (map[string]*dto.MetricFamily, error) {
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) // nolint
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +48,12 @@ func main() {
 
 	mf, err := parseMF(*f)
 	fatal(err)
+
+	// Do not submit, just debugging what's going on...
+	for k, v := range mf {
+		log.Printf("k: %s", k)
+		log.Printf("VALUE: %+v", v)
+	}
 
 	// Just grab the api_latency metric, make sure it's a histogram
 	// and just make sure there is at least one 200, and no errors there.

--- a/test/prometheus/main.go
+++ b/test/prometheus/main.go
@@ -1,0 +1,115 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+func fatal(err error) {
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func parseMF(url string) (map[string]*dto.MetricFamily, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var parser expfmt.TextParser
+	return parser.TextToMetricFamilies(resp.Body)
+}
+
+func main() {
+	f := flag.String("url", "http://fulcio-server.fulcio-dev.svc:2112/metrics", "set url to fetch metrics from")
+	flag.Parse()
+
+	mf, err := parseMF(*f)
+	fatal(err)
+
+	// Just grab the api_latency metric, make sure it's a histogram
+	// and just make sure there is at least one 200, and no errors there.
+	latency, ok := mf["fulcio_api_latency"]
+	if !ok || latency == nil {
+		log.Fatal("Did not get fulcio_api_latency metric")
+	}
+	if err := checkLatency(latency); err != nil {
+		log.Fatalf("fulcio_api_latency metric failed: %s", err)
+	}
+
+	// Then make sure the cert counter went up.
+	certCount, ok := mf["fulcio_new_certs"]
+	if !ok || certCount == nil {
+		log.Fatal("Did not get fulcio_new_certs metric")
+	}
+	if err := checkCertCount(certCount); err != nil {
+		log.Fatalf("fulcio_new_certs metric failed: %s", err)
+	}
+}
+
+// Make sure latency is a Histogram, and it has a POST with a 200.
+func checkLatency(latency *dto.MetricFamily) error {
+	if *latency.Type != *dto.MetricType_HISTOGRAM.Enum() {
+		return fmt.Errorf("Wrong type, wanted %+v, got: %+v", dto.MetricType_HISTOGRAM.Enum(), latency.Type)
+	}
+	if len(latency.Metric) != 1 {
+		return fmt.Errorf("Got multiple entries, or none for metric, wanted one, got: %+v", latency.Metric)
+	}
+	// Make sure there's a 'post' and it's a 200.
+	var code string
+	var method string
+	for _, value := range latency.Metric[0].Label {
+		if *value.Name == "code" {
+			code = *value.Value
+		}
+		if *value.Name == "method" {
+			method = *value.Value
+		}
+	}
+	if code != "200" {
+		return fmt.Errorf("unexpected code, wanted 200, got %s", code)
+	}
+	if method != "post" {
+		return fmt.Errorf("unexpected method, wanted post, got %s", method)
+	}
+
+	if *latency.Metric[0].Histogram.SampleCount != 1 {
+		return fmt.Errorf("Unexpected samplecount, wanted 1, got %d", *latency.Metric[0].Histogram.SampleCount)
+	}
+	return nil
+}
+
+func checkCertCount(certCount *dto.MetricFamily) error {
+	if *certCount.Type != *dto.MetricType_COUNTER.Enum() {
+		return fmt.Errorf("Wrong type, wanted %+v, got: %+v", dto.MetricType_COUNTER.Enum(), certCount.Type)
+	}
+	if len(certCount.Metric) != 1 {
+		return fmt.Errorf("Got multiple entries, or none for metric, wanted one, got: %+v", certCount.Metric)
+	}
+	if *certCount.Metric[0].Counter.Value < 1 {
+		return fmt.Errorf("Got incorrect cert count, wanted one, got: %f", *certCount.Metric[0].Counter.Value)
+	}
+	return nil
+}

--- a/test/prometheus/main.go
+++ b/test/prometheus/main.go
@@ -50,12 +50,6 @@ func main() {
 		log.Fatalf("Failed to fetch/parse metrics: %v", err)
 	}
 
-	// Do not submit, just debugging what's going on...
-	for k, v := range mf {
-		log.Printf("k: %s", k)
-		log.Printf("VALUE: %+v", v)
-	}
-
 	// Just grab the api_latency metric, make sure it's a histogram
 	// and just make sure there is at least one 200, and no errors there.
 	latency, ok := mf[latencyMetric]


### PR DESCRIPTION
Wrap the server with the Prometheus so we get metrics + add an e2e test for it. Note that
the default prometheus metrics (go_*) were already exposed.

I wrapped test in a job, since otherwise it will be trickier to get access to the
metrics from outside the kind cluster.

Fix the dangling pointer from #262 and fix a tiny typo, though I kind of do
like exposing a singingCert that might come handy (should be required?) in karaoke?

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Expose prometheus metrics for: fulcio_api_latency (histogram) and fulcio_new_certs (counter).
```
