### PR TITLE
Make client request timeout configurable with `WithTimeout` client option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ hack/tools/bin
 /server
 /fulcio
 
+# Vim
+*.swp

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
 )
 
 type CertificateResponse struct {
@@ -54,6 +55,7 @@ func NewClient(url *url.URL, opts ...ClientOption) Client {
 		baseURL: url,
 		client: &http.Client{
 			Transport: createRoundTripper(http.DefaultTransport, o),
+			Timeout:   o.Timeout,
 		},
 	}
 }
@@ -120,6 +122,7 @@ func (c *client) SigningCert(cr CertificateRequest, token string) (*CertificateR
 
 type clientOptions struct {
 	UserAgent string
+	Timeout   time.Duration
 }
 
 func makeOptions(opts ...ClientOption) *clientOptions {
@@ -132,6 +135,13 @@ func makeOptions(opts ...ClientOption) *clientOptions {
 	}
 
 	return o
+}
+
+// WithTimeout sets the request timeout for the client
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(o *clientOptions) {
+		o.Timeout = timeout
+	}
 }
 
 // WithUserAgent sets the media type of the signature.

--- a/pkg/api/options_test.go
+++ b/pkg/api/options_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -35,6 +36,10 @@ func TestMakeOptions(t *testing.T) {
 		desc: "WithUserAgent",
 		opts: []ClientOption{WithUserAgent("test user agent")},
 		want: &clientOptions{UserAgent: "test user agent"},
+	}, {
+		desc: "WithTimeout",
+		opts: []ClientOption{WithTimeout(7 * time.Second)},
+		want: &clientOptions{Timeout: 7 * time.Second},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -110,7 +115,7 @@ func TestSanity(t *testing.T) {
 		t.Fatalf("url.Parse(SigstorePublicServerURL) returned error: %v", err)
 	}
 
-	got := NewClient(testURL, WithUserAgent("sanity test"))
+	got := NewClient(testURL, WithUserAgent("sanity test"), WithTimeout(11*time.Second))
 	if got == nil {
 		t.Fatalf(`New(testURL, WithUserAgent("sanity test")) returned nil`)
 	}


### PR DESCRIPTION
#### Summary

Adds a client request timeout option. This closes #266. 

Also adds vim swap files to the gitignore. Can drop this if folks think its not relevant to the PR or repository.

#### Release Note

```release-note
* Added `WithTimeout` client option to configure request timeout
```
