### PR TITLE
Localize flags to each subcommand

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -40,126 +40,136 @@ const (
 	LABEL = "PKCS11CA"
 )
 
-// createcaCmd represents the createca command
-var createcaCmd = &cobra.Command{
-	Use:   "createca",
-	Short: "Create a root CA in a pkcs11 device",
-	Long: `Create an x509 root CA within a pkcs11 device using values
+func newCreateCACmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "createca",
+		Short: "Create a root CA in a pkcs11 device",
+		Long: `Create an x509 root CA within a pkcs11 device using values
 such as organization, country etc. This can then be used as the root
 certificate authority for an instance of sigstore fulcio`,
-	Run: func(cmd *cobra.Command, args []string) {
-		log.Logger.Info("binding to PKCS11 HSM")
-		p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-		defer p11Ctx.Close()
+		Run: runCreateCACmd,
+	}
 
-		rootID := []byte(viper.GetString("hsm-caroot-id"))
+	cmd.Flags().String("org", "Fulcio Root CA", "Organization name for root CA")
+	cmd.Flags().String("country", "", "Country name for root CA")
+	cmd.Flags().String("province", "", "Province name for root CA")
+	cmd.Flags().String("locality", "", "Locality name for root CA")
+	cmd.Flags().String("street-address", "", "Street address for root CA")
+	cmd.Flags().String("postal-code", "", "Postal code for root CA")
+	cmd.Flags().String("out", "", "output root CA to file")
+	cmd.Flags().String("hsm", "softhsm", "The HSM provider to use. Valid values: softhsm (default), aws")
+	cmd.Flags().String("pkcs11-config-path", "config/crypto11.conf", "path to fulcio pkcs11 config file")
+	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA")
 
-		// Check if CA already exists (or a cert within the provided ID)
-		findCA, err := p11Ctx.FindCertificate(rootID, nil, nil)
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-		if findCA != nil {
-			log.Logger.Fatal("certificate already exists with this ID")
-		}
+	err := cmd.MarkFlagRequired("hsm-caroot-id")
+	if err != nil {
+		log.Logger.Fatal(`Failed to mark flag as required`)
+	}
 
-		// Find the existing Key Pair
-		// TODO: We could make the TAG customizable
-		log.Logger.Info("finding slot for private key: ", LABEL)
-		privKey, err := p11Ctx.FindKeyPair(nil, []byte(LABEL))
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-
-		pubKey := privKey.Public()
-
-		// TODO: We could make it so this could be passed in by the user
-		serialNumber, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-		rootCA := &x509.Certificate{
-			SerialNumber: serialNumber,
-			Subject: pkix.Name{
-				Organization:  []string{viper.GetString("org")},
-				Country:       []string{viper.GetString("country")},
-				Province:      []string{viper.GetString("province")},
-				Locality:      []string{viper.GetString("locality")},
-				StreetAddress: []string{viper.GetString("street-address")},
-				PostalCode:    []string{viper.GetString("postal-code")},
-			},
-			NotBefore:             time.Now(),
-			NotAfter:              time.Now().AddDate(10, 0, 0),
-			IsCA:                  true,
-			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-			BasicConstraintsValid: true, MaxPathLen: 1,
-		}
-
-		caBytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, pubKey, privKey)
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-
-		pemBytes := pem.EncodeToMemory(&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: caBytes,
-		})
-
-		log.Logger.Info("Root CA:")
-		fmt.Println(string(pemBytes))
-
-		certParse, err := x509.ParseCertificate(caBytes)
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-
-		// Import the root CA into the HSM
-		// TODO: We could make the TAG customizable
-		if viper.GetString("hsm") == "aws" {
-			log.Logger.Info("Running in AWS mode; skipping root CA storage in HSM")
-			if !viper.IsSet("out") {
-				log.Logger.Warn("WARNING: --out is not set. Root CA will not be saved.")
-			}
-		} else {
-			if err = p11Ctx.ImportCertificateWithLabel(rootID, []byte(LABEL), certParse); err != nil {
-				log.Logger.Fatal(err)
-			}
-			log.Logger.Info("root CA created with PKCS11 ID: ", viper.GetString("hsm-caroot-id"))
-		}
-
-		// Save out the file in pem format for easy import to CTL chain
-		if viper.IsSet("out") {
-			certOut, err := os.Create(filepath.Clean(viper.GetString("out")))
-			if err != nil {
-				log.Logger.Fatal(err)
-			}
-			if err := pem.Encode(certOut, &pem.Block{ //nolint
-				Type:  "CERTIFICATE",
-				Bytes: caBytes},
-			); err != nil {
-				certOut.Close()
-				log.Logger.Fatal(err)
-			}
-			certOut.Close()
-			log.Logger.Info("root CA saved to file: ", viper.GetString("out"))
-		}
-	},
+	return cmd
 }
 
-func init() {
-	rootCmd.AddCommand(createcaCmd)
-	createcaCmd.PersistentFlags().String("org", "Fulcio Root CA", "Organization name for root CA")
-	createcaCmd.PersistentFlags().String("country", "", "Country name for root CA")
-	createcaCmd.PersistentFlags().String("province", "", "Province name for root CA")
-	createcaCmd.PersistentFlags().String("locality", "", "Locality name for root CA")
-	createcaCmd.PersistentFlags().String("street-address", "", "Street address for root CA")
-	createcaCmd.PersistentFlags().String("postal-code", "", "Postal code for root CA")
-	createcaCmd.PersistentFlags().String("out", "", "output root CA to file")
-	createcaCmd.PersistentFlags().String("hsm", "softhsm", "The HSM provider to use. Valid values: softhsm (default), aws")
-	if err := viper.BindPFlags(createcaCmd.PersistentFlags()); err != nil {
+func runCreateCACmd(cmd *cobra.Command, args []string) {
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
 		log.Logger.Fatal(err)
+	}
+
+	log.Logger.Info("binding to PKCS11 HSM")
+	p11Ctx, err := crypto11.ConfigureFromFile(viper.GetString("pkcs11-config-path"))
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+	defer p11Ctx.Close()
+
+	rootID := []byte(viper.GetString("hsm-caroot-id"))
+
+	// Check if CA already exists (or a cert within the provided ID)
+	findCA, err := p11Ctx.FindCertificate(rootID, nil, nil)
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+	if findCA != nil {
+		log.Logger.Fatal("certificate already exists with this ID")
+	}
+
+	// Find the existing Key Pair
+	// TODO: We could make the TAG customizable
+	log.Logger.Info("finding slot for private key: ", LABEL)
+	privKey, err := p11Ctx.FindKeyPair(nil, []byte(LABEL))
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+
+	pubKey := privKey.Public()
+
+	// TODO: We could make it so this could be passed in by the user
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+	rootCA := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization:  []string{viper.GetString("org")},
+			Country:       []string{viper.GetString("country")},
+			Province:      []string{viper.GetString("province")},
+			Locality:      []string{viper.GetString("locality")},
+			StreetAddress: []string{viper.GetString("street-address")},
+			PostalCode:    []string{viper.GetString("postal-code")},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true, MaxPathLen: 1,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, pubKey, privKey)
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	log.Logger.Info("Root CA:")
+	fmt.Println(string(pemBytes))
+
+	certParse, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+
+	// Import the root CA into the HSM
+	// TODO: We could make the TAG customizable
+	if viper.GetString("hsm") == "aws" {
+		log.Logger.Info("Running in AWS mode; skipping root CA storage in HSM")
+		if !viper.IsSet("out") {
+			log.Logger.Warn("WARNING: --out is not set. Root CA will not be saved.")
+		}
+	} else {
+		if err = p11Ctx.ImportCertificateWithLabel(rootID, []byte(LABEL), certParse); err != nil {
+			log.Logger.Fatal(err)
+		}
+		log.Logger.Info("root CA created with PKCS11 ID: ", viper.GetString("hsm-caroot-id"))
+	}
+
+	// Save out the file in pem format for easy import to CTL chain
+	if viper.IsSet("out") {
+		certOut, err := os.Create(filepath.Clean(viper.GetString("out")))
+		if err != nil {
+			log.Logger.Fatal(err)
+		}
+		if err := pem.Encode(certOut, &pem.Block{ //nolint
+			Type:  "CERTIFICATE",
+			Bytes: caBytes},
+		); err != nil {
+			certOut.Close()
+			log.Logger.Fatal(err)
+		}
+		certOut.Close()
+		log.Logger.Info("root CA saved to file: ", viper.GetString("out"))
 	}
 }

--- a/cmd/app/root.go
+++ b/cmd/app/root.go
@@ -20,13 +20,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/sigstore/fulcio/pkg/log"
-)
-
-var (
-	logType string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -46,19 +41,7 @@ func Execute(ctx context.Context) {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&logType, "log_type", "dev", "logger type to use (dev/prod)")
-	rootCmd.PersistentFlags().String("ca", "", "googleca | pkcs11ca | ephemeralca (for testing)")
-	rootCmd.PersistentFlags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
-	rootCmd.PersistentFlags().String("gcp_private_ca_parent", "", "private ca parent: /projects/<project>/locations/<location>/<name> (only used with --ca googleca)")
-	rootCmd.PersistentFlags().String("gcp_private_ca_version", "v1", "private ca version: [v1|v1beta1] (only used with --ca googleca)")
-	rootCmd.PersistentFlags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
-	rootCmd.PersistentFlags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
-	rootCmd.PersistentFlags().String("config-path", "/etc/fulcio-config/config.json", "path to fulcio config json")
-	rootCmd.PersistentFlags().String("pkcs11-config-path", "config/crypto11.conf", "path to fulcio pkcs11 config file")
-	rootCmd.PersistentFlags().String("host", "0.0.0.0", "The host on which to serve requests")
-	rootCmd.PersistentFlags().String("port", "8080", "The port on which to serve requests")
-
-	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
-		log.Logger.Fatal(err)
-	}
+	rootCmd.AddCommand(newCreateCACmd())
+	rootCmd.AddCommand(newServeCmd())
+	rootCmd.AddCommand(newVersionCmd())
 }

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -33,113 +33,134 @@ import (
 	"github.com/spf13/viper"
 )
 
-// serveCmd represents the serve command
-var serveCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "start http server with configured api",
-	Long:  `Starts a http server and serves the configured api`,
-	Run: func(cmd *cobra.Command, args []string) {
+func newServeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "start http server with configured api",
+		Long:  `Starts a http server and serves the configured api`,
+		Run:   runServeCmd,
+	}
 
-		switch viper.GetString("ca") {
-		case "pkcs11ca":
-			if !viper.IsSet("hsm-caroot-id") {
-				log.Logger.Fatal("hsm-caroot-id must be set when using pkcs11ca")
-			}
+	cmd.Flags().String("log_type", "dev", "logger type to use (dev/prod)")
+	cmd.Flags().String("ca", "", "googleca | pkcs11ca | ephemeralca (for testing)")
+	cmd.Flags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
+	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: /projects/<project>/locations/<location>/<name> (only used with --ca googleca)")
+	cmd.Flags().String("gcp_private_ca_version", "v1", "private ca version: [v1|v1beta1] (only used with --ca googleca)")
+	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
+	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
+	cmd.Flags().String("config-path", "/etc/fulcio-config/config.json", "path to fulcio config json")
+	cmd.Flags().String("pkcs11-config-path", "config/crypto11.conf", "path to fulcio pkcs11 config file")
+	cmd.Flags().String("host", "0.0.0.0", "The host on which to serve requests")
+	cmd.Flags().String("port", "8080", "The port on which to serve requests")
 
-		case "googleca":
-			if !viper.IsSet("gcp_private_ca_parent") {
-				log.Logger.Fatal("gcp_private_ca_parent must be set when using googleca")
-			}
+	err := cmd.MarkFlagRequired("ca")
+	if err != nil {
+		log.Logger.Fatal(`Failed to mark flag as required`)
+	}
 
-		case "ephemeralca":
-			// this is a no-op since this is a self-signed in-memory CA for testing
-		default:
-			log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
-		}
-
-		// Setup the logger to dev/prod
-		log.ConfigureLogger(viper.GetString("log_type"))
-
-		// from https://github.com/golang/glog/commit/fca8c8854093a154ff1eb580aae10276ad6b1b5f
-		_ = flag.CommandLine.Parse([]string{})
-
-		cfg, err := config.Load(viper.GetString("config-path"))
-		if err != nil {
-			log.Logger.Fatalf("error loading config: %v", err)
-		}
-
-		var baseca certauth.CertificateAuthority
-		switch viper.GetString("ca") {
-		case "googleca":
-			version := viper.GetString("gcp_private_ca_version")
-			switch version {
-			case "v1":
-				baseca, err = googlecav1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
-			case "v1beta1":
-				baseca, err = googlecav1beta1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
-			default:
-				err = fmt.Errorf("invalid value for gcp_private_ca_version: %v", version)
-			}
-		case "pkcs11ca":
-			params := x509ca.Params{
-				ConfigPath: viper.GetString("pkcs11-config-path"),
-				RootID:     viper.GetString("hsm-caroot-id"),
-			}
-			if viper.IsSet("aws-hsm-root-ca-path") {
-				path := viper.GetString("aws-hsm-root-ca-path")
-				params.CAPath = &path
-			}
-			baseca, err = x509ca.NewX509CA(params)
-		case "ephemeralca":
-			baseca, err = ephemeralca.NewEphemeralCA()
-		default:
-			err = fmt.Errorf("invalid value for configured CA: %v", baseca)
-		}
-		if err != nil {
-			log.Logger.Fatal(err)
-		}
-
-		decorateHandler := func(h http.Handler) http.Handler {
-			// Wrap the inner func with instrumentation to get latencies
-			// that get partitioned by 'code' and 'method'.
-			return promhttp.InstrumentHandlerDuration(
-				api.MetricLatency,
-				http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-					ctx := r.Context()
-
-					// For each request, infuse context with our snapshot of the FulcioConfig.
-					// TODO(mattmoor): Consider periodically (every minute?) refreshing the ConfigMap
-					// from disk, so that we don't need to cycle pods to pick up config updates.
-					// Alternately we could take advantage of Knative's configmap watcher.
-					ctx = config.With(ctx, cfg)
-					ctx = api.WithCA(ctx, baseca)
-					ctx = api.WithCTLogURL(ctx, viper.GetString("ct-log-url"))
-
-					h.ServeHTTP(rw, r.WithContext(ctx))
-				}))
-		}
-
-		prom := http.Server{
-			Addr:    ":2112",
-			Handler: promhttp.Handler(),
-		}
-		go func() {
-			_ = prom.ListenAndServe()
-		}()
-
-		host, port := viper.GetString("host"), viper.GetString("port")
-		log.Logger.Infof("%s:%s", host, port)
-		api := http.Server{
-			Addr:    host + ":" + port,
-			Handler: decorateHandler(api.NewHandler()),
-		}
-
-		if err := api.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Logger.Fatal(err)
-		}
-	},
+	return cmd
 }
 
-func init() {
-	rootCmd.AddCommand(serveCmd)
+func runServeCmd(cmd *cobra.Command, args []string) {
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
+		log.Logger.Fatal(err)
+	}
+
+	switch viper.GetString("ca") {
+	case "pkcs11ca":
+		if !viper.IsSet("hsm-caroot-id") {
+			log.Logger.Fatal("hsm-caroot-id must be set when using pkcs11ca")
+		}
+
+	case "googleca":
+		if !viper.IsSet("gcp_private_ca_parent") {
+			log.Logger.Fatal("gcp_private_ca_parent must be set when using googleca")
+		}
+
+	case "ephemeralca":
+		// this is a no-op since this is a self-signed in-memory CA for testing
+	default:
+		log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
+	}
+
+	// Setup the logger to dev/prod
+	log.ConfigureLogger(viper.GetString("log_type"))
+
+	// from https://github.com/golang/glog/commit/fca8c8854093a154ff1eb580aae10276ad6b1b5f
+	_ = flag.CommandLine.Parse([]string{})
+
+	cfg, err := config.Load(viper.GetString("config-path"))
+	if err != nil {
+		log.Logger.Fatalf("error loading config: %v", err)
+	}
+
+	var baseca certauth.CertificateAuthority
+	switch viper.GetString("ca") {
+	case "googleca":
+		version := viper.GetString("gcp_private_ca_version")
+		switch version {
+		case "v1":
+			baseca, err = googlecav1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
+		case "v1beta1":
+			baseca, err = googlecav1beta1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
+		default:
+			err = fmt.Errorf("invalid value for gcp_private_ca_version: %v", version)
+		}
+	case "pkcs11ca":
+		params := x509ca.Params{
+			ConfigPath: viper.GetString("pkcs11-config-path"),
+			RootID:     viper.GetString("hsm-caroot-id"),
+		}
+		if viper.IsSet("aws-hsm-root-ca-path") {
+			path := viper.GetString("aws-hsm-root-ca-path")
+			params.CAPath = &path
+		}
+		baseca, err = x509ca.NewX509CA(params)
+	case "ephemeralca":
+		baseca, err = ephemeralca.NewEphemeralCA()
+	default:
+		err = fmt.Errorf("invalid value for configured CA: %v", baseca)
+	}
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
+
+	decorateHandler := func(h http.Handler) http.Handler {
+		// Wrap the inner func with instrumentation to get latencies
+		// that get partitioned by 'code' and 'method'.
+		return promhttp.InstrumentHandlerDuration(
+			api.MetricLatency,
+			http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				ctx := r.Context()
+
+				// For each request, infuse context with our snapshot of the FulcioConfig.
+				// TODO(mattmoor): Consider periodically (every minute?) refreshing the ConfigMap
+				// from disk, so that we don't need to cycle pods to pick up config updates.
+				// Alternately we could take advantage of Knative's configmap watcher.
+				ctx = config.With(ctx, cfg)
+				ctx = api.WithCA(ctx, baseca)
+				ctx = api.WithCTLogURL(ctx, viper.GetString("ct-log-url"))
+
+				h.ServeHTTP(rw, r.WithContext(ctx))
+			}))
+	}
+
+	prom := http.Server{
+		Addr:    ":2112",
+		Handler: promhttp.Handler(),
+	}
+	go func() {
+		_ = prom.ListenAndServe()
+	}()
+
+	host, port := viper.GetString("host"), viper.GetString("port")
+	log.Logger.Infof("%s:%s", host, port)
+	api := http.Server{
+		Addr:    host + ":" + port,
+		Handler: decorateHandler(api.NewHandler()),
+	}
+
+	if err := api.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Logger.Fatal(err)
+	}
 }

--- a/cmd/app/version.go
+++ b/cmd/app/version.go
@@ -48,19 +48,18 @@ type versionOptions struct {
 
 var versionOpts = &versionOptions{}
 
-// verifyCmd represents the verify command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "fulcio-server version",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runVersion(versionOpts)
-	},
-}
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "print build version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(versionOpts)
+		},
+	}
 
-func init() {
-	versionCmd.PersistentFlags().BoolVarP(&versionOpts.json, "json", "j", false,
-		"print JSON instead of text")
-	rootCmd.AddCommand(versionCmd)
+	cmd.Flags().BoolVarP(&versionOpts.json, "json", "j", false, "print JSON instead of text")
+
+	return cmd
 }
 
 func runVersion(opts *versionOptions) error {


### PR DESCRIPTION
#### Summary

Makes CLI usage a little more clear by moving global flags to their relevant subcommands. 

**Before**

```bash
$ fulcio createca -h
Create an x509 root CA within a pkcs11 device using values
such as organization, country etc. This can then be used as the root
certificate authority for an instance of sigstore fulcio

Usage:
  fulcio createca [flags]

Flags:
      --country string          Country name for root CA
  -h, --help                    help for createca
      --hsm string              The HSM provider to use. Valid values: softhsm (default), aws (default "softhsm")
      --locality string         Locality name for root CA
      --org string              Organization name for root CA (default "Fulcio Root CA")
      --out string              output root CA to file
      --postal-code string      Postal code for root CA
      --province string         Province name for root CA
      --street-address string   Street address for root CA

Global Flags:
      --aws-hsm-root-ca-path string     Path to root CA on disk (only used with AWS HSM)
      --ca string                       googleca | pkcs11ca | ephemeralca (for testing)
      --config-path string              path to fulcio config json (default "/etc/fulcio-config/config.json")
      --ct-log-url string               host and path (with log prefix at the end) to the ct log (default "http://localhost:6962/test")
      --gcp_private_ca_parent string    private ca parent: /projects/<project>/locations/<location>/<name> (only used with --ca googleca)
      --gcp_private_ca_version string   private ca version: [v1|v1beta1] (only used with --ca googleca) (default "v1")
      --host string                     The host on which to serve requests (default "0.0.0.0")
      --hsm-caroot-id string            HSM ID for Root CA (only used with --ca pkcs11ca)
      --log_type string                 logger type to use (dev/prod) (default "dev")
      --pkcs11-config-path string       path to fulcio pkcs11 config file (default "config/crypto11.conf")
      --port string                     The port on which to serve requests (default "8080")
```
> NB: The flags like `--port` that are completely irrelevant to `createca` and are only needed for `serve`

**After**

```bash
fulcio createca -h
Create an x509 root CA within a pkcs11 device using values
such as organization, country etc. This can then be used as the root
certificate authority for an instance of sigstore fulcio

Usage:
  fulcio createca [flags]

Flags:
      --country string              Country name for root CA
  -h, --help                        help for createca
      --hsm string                  The HSM provider to use. Valid values: softhsm (default), aws (default "softhsm")
      --hsm-caroot-id string        HSM ID for Root CA
      --locality string             Locality name for root CA
      --org string                  Organization name for root CA (default "Fulcio Root CA")
      --out string                  output root CA to file
      --pkcs11-config-path string   path to fulcio pkcs11 config file (default "config/crypto11.conf")
      --postal-code string          Postal code for root CA
      --province string             Province name for root CA
      --street-address string       Street address for root CA
```

#### Ticket Link

Fixes #273 

#### Release Note

```release-note
* Removed global flags from CLI and moved flags to their relevant subcommands
```
