### PR TITLE
Do not close the PKCS11 context on startup

### DIFF
--- a/pkg/ca/x509ca/x509ca.go
+++ b/pkg/ca/x509ca/x509ca.go
@@ -40,7 +40,6 @@ func NewX509CA(params Params) (*X509CA, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer p11Ctx.Close()
 
 	rootID := []byte(params.RootID)
 


### PR DESCRIPTION
When Fulcio is started with PKCS11 CA, every signing request fails with
"context is closed" error. This is because the private key is loaded
once but then its context is closed. The private key of the CA doesn't
change during the entire lifecycle of Fulcio and it cannot be used
without active context.

Closes: #281

Signed-off-by: Radoslav Gerganov <rgerganov@vmware.com>

