### PR TITLE
Fail fast if private key is not found when using PKCS11 CA

### DIFF
--- a/pkg/ca/x509ca/x509ca.go
+++ b/pkg/ca/x509ca/x509ca.go
@@ -71,6 +71,9 @@ func NewX509CA(params Params) (*X509CA, error) {
 	if err != nil {
 		return nil, err
 	}
+	if ca.PrivKey == nil {
+		return nil, errors.New("cannot find private key")
+	}
 
 	return ca, nil
 


### PR DESCRIPTION
When Fulcio is using pkcs11, it expects a private key under the
"PKCS11CA" label. If there is no such key, Fulcio starts successfully
but fails on the first signing request. A much better behavior is to
fail fast and inform the user that the private key is not found upon
start.

Closes: #284
