### PR TITLE
Handle error when there are no roots returned by CA Service

### DIFF
--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -151,10 +151,16 @@ func (c *CertAuthorityService) Root(ctx context.Context) ([]byte, error) {
 			if done == iterator.Done {
 				break
 			}
+			if done != nil {
+				break
+			}
 			pems += strings.Join(c.PemCaCertificates, "")
 		}
 		c.cachedRoots = []byte(pems)
 	})
+	if len(c.cachedRoots) == 0 {
+		return c.cachedRoots, fmt.Errorf("error fetching root certificates")
+	}
 	return c.cachedRoots, nil
 }
 

--- a/pkg/ca/googleca/v1beta1/googleca.go
+++ b/pkg/ca/googleca/v1beta1/googleca.go
@@ -157,10 +157,16 @@ func (c *CertAuthorityService) Root(ctx context.Context) ([]byte, error) {
 			if done == iterator.Done {
 				break
 			}
+			if done != nil {
+				break
+			}
 			pems += strings.Join(c.PemCaCertificates, "")
 		}
 		c.cachedRoots = []byte(pems)
 	})
+	if len(c.cachedRoots) == 0 {
+		return c.cachedRoots, fmt.Errorf("error fetching root certificates")
+	}
 	return c.cachedRoots, nil
 }
 


### PR DESCRIPTION
This occurs when authentication is not properly set up. Otherwise,
the service crashes with a nil pointer dereference.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>


