### PR TITLE
Extract additional claims from github-workflow token

### DIFF
--- a/OID_INFO.md
+++ b/OID_INFO.md
@@ -15,4 +15,9 @@ Note that all values begin from the root OID 1.3.6.1.4.1.57264 [registered by Da
     - This contains the `event_name` claim from the GitHub OIDC Identity token that contains the name of the event that triggered the workflow run. [(docs)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)
 - *1.3.6.1.4.1.57264.1.3*: (GithubWorkflowSha)
     - This contains the `sha` claim from the GitHub OIDC Identity token that contains the commit SHA that the workflow run was based upon. [(docs)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)
-
+- *1.3.6.1.4.1.57264.1.4*: (GithubWorkflowName)
+    - This contains the `workflow` claim from the GitHub OIDC Identity token that contains the name of the executed workflow. [(docs)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)
+- *1.3.6.1.4.1.57264.1.5*: (GithubWorkflowRepository)
+    - This contains the `repository` claim from the GitHub OIDC Identity token that contains the repository that the workflow run was based upon. [(docs)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)
+- *1.3.6.1.4.1.57264.1.6*: (GithubWorkflowRef)
+    - This contains the `ref` claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon. [(docs)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -115,6 +115,27 @@ func AdditionalExtensions(subject *challenges.ChallengeResult) []pkix.Extension 
 				Value: []byte(sha),
 			})
 		}
+
+		if name, ok := subject.AdditionalInfo[challenges.GithubWorkflowName]; ok {
+			res = append(res, pkix.Extension{
+				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 4},
+				Value: []byte(name),
+			})
+		}
+
+		if repo, ok := subject.AdditionalInfo[challenges.GithubWorkflowRepository]; ok {
+			res = append(res, pkix.Extension{
+				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 5},
+				Value: []byte(repo),
+			})
+		}
+
+		if ref, ok := subject.AdditionalInfo[challenges.GithubWorkflowRef]; ok {
+			res = append(res, pkix.Extension{
+				Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 6},
+				Value: []byte(ref),
+			})
+		}
 	}
 	return res
 }

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -46,6 +46,9 @@ type AdditionalInfo int
 const (
 	GithubWorkflowTrigger AdditionalInfo = iota
 	GithubWorkflowSha
+	GithubWorkflowName
+	GithubWorkflowRepository
+	GithubWorkflowRef
 )
 
 type ChallengeResult struct {
@@ -254,8 +257,11 @@ func workflowFromIDToken(token *oidc.IDToken) (string, error) {
 func workflowInfoFromIDToken(token *oidc.IDToken) (map[AdditionalInfo]string, error) {
 	// Extract custom claims
 	var claims struct {
-		Sha     string `json:"sha"`
-		Trigger string `json:"event_name"`
+		Sha        string `json:"sha"`
+		Trigger    string `json:"event_name"`
+		Repository string `json:"repository"`
+		Workflow   string `json:"workflow"`
+		Ref        string `json:"ref"`
 		// The other fields that are present here seem to depend on the type
 		// of workflow trigger that initiated the action.
 	}
@@ -265,8 +271,11 @@ func workflowInfoFromIDToken(token *oidc.IDToken) (map[AdditionalInfo]string, er
 
 	// We use this in URIs, so it has to be a URI.
 	return map[AdditionalInfo]string{
-		GithubWorkflowSha:     claims.Sha,
-		GithubWorkflowTrigger: claims.Trigger}, nil
+		GithubWorkflowSha:        claims.Sha,
+		GithubWorkflowTrigger:    claims.Trigger,
+		GithubWorkflowName:       claims.Workflow,
+		GithubWorkflowRepository: claims.Repository,
+		GithubWorkflowRef:        claims.Ref}, nil
 }
 
 func isSpiffeIDAllowed(host, spiffeID string) bool {


### PR DESCRIPTION
With reusable github-workflows the "job_workflow_ref" will reference the shared workflow instead the actual calling workflow.

#### Summary
This adds the additional infos `repository`, `workflow` and `ref` from the Github-Workflow OIDC token as described in #305. According to the [Github-Docs](https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows#how-the-token-works-with-reusable-workflows) I added the `repository` field instead of the `repo`.

#### Ticket Link
Fixes #305

#### Release Note
```release-note
job_workflow_ref info was insufficient when using with shared github-workflows
```
