### PR TITLE
Enable server settings via config file and env vars

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -136,10 +136,6 @@ jobs:
           # Reduce the resource requests of Fulcio
           sed -i -e 's,memory: "1G",memory: "100m",g' ${{ github.workspace }}/config/deployment.yaml
           sed -i -e 's,cpu: ".5",cpu: "50m",g' ${{ github.workspace }}/config/deployment.yaml
-          # Switch to the ephemeralca for testing.
-          sed -i -e 's,--ca=googleca,--ca=ephemeralca,g' ${{ github.workspace }}/config/deployment.yaml
-          # Drop the ct-log flag's value to elide CT-log uploads.
-          sed -i -E 's,"--ct-log-url=[^"]+","--ct-log-url=",g' ${{ github.workspace }}/config/deployment.yaml
           # Switch to one replica to make it easier to test the scraping of
           # metrics since we know all the requests then go to the same server.
           sed -i -E 's,replicas: 3,replicas: 1,g' ${{ github.workspace }}/config/deployment.yaml
@@ -171,9 +167,16 @@ jobs:
             namespace: fulcio-dev
           data:
             config.json: |-
-                {
-                  ${{ matrix.issuer-config }}
-                }
+              {
+                ${{ matrix.issuer-config }}
+              }
+            server.yaml: |-
+              host: 0.0.0.0
+              port: 5555
+              ca: ephemeralca
+              gcp_private_ca_version: v1
+              ct-log-url: ""
+              log_type: prod
           EOF
 
           kubectl create ns fulcio-dev

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -41,13 +41,10 @@ spec:
         - containerPort: 5555
         - containerPort: 2112 # metrics
         args: [
-          "serve",
-          "--host=0.0.0.0", "--port=5555",
-          "--ca=googleca", "--gcp_private_ca_parent=$(CA_PARENT)", "--gcp_private_ca_version=v1",
-          "--ct-log-url=http://ct-log/test", "--log_type=prod",
+          "serve", "-c", "/etc/fulcio-config/server.yaml",
         ]
         env:
-        - name: CA_PARENT
+        - name: FULCIO_SERVE_GCP_PRIVATE_CA_PARENT
           valueFrom:
             configMapKeyRef:
               name: private-ca

--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -55,6 +55,13 @@ data:
             }
           }
         }
+    server.yaml: |-
+        host: 0.0.0.0
+        port: 5555
+        ca: googleca
+        gcp_private_ca_version: v1
+        ct-log-url: http://ct-log/test
+        log_type: prod
 kind: ConfigMap
 metadata:
     name: fulcio-config


### PR DESCRIPTION
Modify the viper settings in the serve subcommand to allow users to provide a config file using -c/--config vs. setting everything using command line flags.

Sinc this is based upon viper, the following config file extensions are supported: "json", "toml", "yaml", "yml", "properties", "props", "prop", "hcl", "tfvars", "dotenv", "env", and "ini".

This change also allows using env vars prefixed with FULCIO_SERVE to provide configuration settings as well.

Resolves #314