### PR TITLE
Fix docker-compose dexidp startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - ct_server
   dex-idp:
     image: dexidp/dex:v2.30.0
+    user: root
     command: [
       "dex",
       "serve",


### PR DESCRIPTION
There was some change in the last year to use a non-root
user for the Dex image. This causes permission issues
when mounting files, since the non-root user cannot
access the mount. The workaround is to run as root,
which should be fine for development.

See https://github.com/dexidp/dex/issues/1649

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

