### PR TITLE
release: add cloudbuild to run the release for fulcio

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,62 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI-Validate-Release-Job
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+
+jobs:
+  validate-release-job:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | sed -r 's/^.*://g'| uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+
+      - name: goreleaser snapshot
+        run: |
+          docker run --rm --privileged \
+            -e PROJECT_ID=honk-fake-project \
+            -v ${PWD}:/go/src/sigstore/fulcio \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /go/src/sigstore/fulcio \
+            --entrypoint="" \
+            ghcr.io/gythialy/golang-cross:v1.17.6-1@sha256:f9a94f9dcc1b1396e3b64725cd5333cf9d4e3e05487bf524ecf9e43989244743 \
+            make snapshot
+
+      - name: check binaries
+        run: |
+          ./dist/fulcio-linux-amd64 version

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -53,7 +53,9 @@ jobs:
       # thus allowing us to test without bypassing tag-to-digest resolution.
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000
-      KO_DOCKER_REPO: registry.local:5000/fulcio
+      KO_PREFIX: registry.local:5000/fulcio
+      GIT_HASH: ${{ github.sha }}
+      GIT_VERSION: test
 
     steps:
       - uses: actions/checkout@v2.4.0
@@ -134,7 +136,7 @@ jobs:
       - name: Deploy fulcio-dev
         run: |
           # Reduce the resource requests of Fulcio
-          sed -i -e 's,memory: "1G",memory: "100m",g' ${{ github.workspace }}/config/deployment.yaml
+          sed -i -e 's,memory: "1G",memory: "100Mi",g' ${{ github.workspace }}/config/deployment.yaml
           sed -i -e 's,cpu: ".5",cpu: "50m",g' ${{ github.workspace }}/config/deployment.yaml
           # Switch to one replica to make it easier to test the scraping of
           # metrics since we know all the requests then go to the same server.
@@ -181,7 +183,7 @@ jobs:
 
           kubectl create ns fulcio-dev
 
-          ko apply -Bf config/
+          make ko-apply
 
           kubectl wait --for=condition=Available --timeout=5m -n fulcio-dev deployment/fulcio-server
 
@@ -189,7 +191,7 @@ jobs:
 
       - name: Run signing job
         run: |
-          DIGEST=$(ko publish .)
+          DIGEST=$(make ko-publish | sed '1d')
 
           cat <<EOF | kubectl apply -f -
           apiVersion: batch/v1
@@ -203,7 +205,7 @@ jobs:
                 automountServiceAccountToken: false
                 containers:
                 - name: check-oidc
-                  image: gcr.io/projectsigstore/cosign:v1.4.0
+                  image: gcr.io/projectsigstore/cosign:v1.4.1
                   args: [
                     "sign",
                     "--fulcio-url=http://fulcio-server.fulcio-dev.svc",
@@ -248,6 +250,8 @@ jobs:
           EOF
 
           kubectl wait --for=condition=Complete --timeout=90s job/check-prometheus-metrics
+        env:
+          KO_DOCKER_REPO: registry.local:5000/fulcio
 
       - name: Collect logs
         if: ${{ always() }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,134 @@
+project_name: fulcio
+
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=1
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - COSIGN_EXPERIMENTAL=true
+
+# Prevents parallel builds from stepping on eachothers toes downloading modules
+before:
+  hooks:
+    - go mod tidy
+
+gomod:
+  proxy: true
+
+sboms:
+- artifacts: binary
+
+builds:
+- id: fulcio-linux-amd64
+  binary: fulcio-linux-amd64
+  no_unique_dist_dir: true
+  main: .
+  goos:
+  - linux
+  goarch:
+  - amd64
+  flags:
+  - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  env:
+  - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
+
+- id: fulcio-linux-arm64
+  binary: fulcio-linux-arm64
+  no_unique_dist_dir: true
+  main: .
+  goos:
+  - linux
+  goarch:
+  - arm64
+  flags:
+  - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  env:
+    - CC=aarch64-linux-gnu-gcc
+
+- id: fulcio-linux-arm
+  binary: fulcio-linux-arm
+  no_unique_dist_dir: true
+  main: .
+  goos:
+  - linux
+  goarch:
+  - arm
+  goarm:
+  - 7
+  flags:
+  - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  env:
+  - CC=arm-linux-gnueabihf-gcc
+
+- id: fulcio-linux-s390x
+  binary: fulcio-linux-s390x
+  no_unique_dist_dir: true
+  main: .
+  goos:
+  - linux
+  goarch:
+  - s390x
+  flags:
+  - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  env:
+  - CC=s390x-linux-gnu-gcc
+
+- id: fulcio-linux-ppc64le
+  binary: fulcio-linux-ppc64le
+  no_unique_dist_dir: true
+  main: .
+  goos:
+  - linux
+  goarch:
+  - ppc64le
+  flags:
+  - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  env:
+  - CC=powerpc64le-linux-gnu-gcc
+
+signs:
+  - signature: "${artifact}.sig"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    artifacts: binary
+  # Keyless
+  - id: fulcio-keyless
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
+    artifacts: binary
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+release:
+  prerelease: allow # remove this when we start publishing non-prerelease or set to auto
+  draft: true # allow for manual edits
+  github:
+    owner: sigstore
+    name: fulcio
+  footer: |
+    ### Thanks for all contributors!

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -7,3 +7,12 @@ builds:
 # comment out above), though it does remove the support for the "createca" command.
 # But at least you can deploy it from M1 using this.
 #  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - -tags
+  - "{{ .Env.GIT_HASH }}"
+  - -tags
+  - "{{ .Env.GIT_VERSION }}"
+  ldflags:
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"

--- a/Makefile
+++ b/Makefile
@@ -38,34 +38,46 @@ ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"
 endif
 
-SERVER_PKG=github.com/sigstore/fulcio/cmd/app
-SERVER_LDFLAGS="-X $(SERVER_PKG).gitVersion=$(GIT_VERSION) -X $(SERVER_PKG).gitCommit=$(GIT_HASH) -X $(SERVER_PKG).gitTreeState=$(GIT_TREESTATE) -X $(SERVER_PKG).buildDate=$(BUILD_DATE)"
-	
+FULCIO_PKG=github.com/sigstore/fulcio/cmd/app
+LDFLAGS=-X $(FULCIO_PKG).gitVersion=$(GIT_VERSION) -X $(FULCIO_PKG).gitCommit=$(GIT_HASH) -X $(FULCIO_PKG).gitTreeState=$(GIT_TREESTATE) -X $(FULCIO_PKG).buildDate=$(BUILD_DATE)
 
-lint:
+KO_PREFIX ?= gcr.io/projectsigstore
+export KO_DOCKER_REPO=$(KO_PREFIX)
+
+lint: ## Runs golangci-lint
 	$(GOBIN)/golangci-lint run -v ./...
 
-gosec:
+gosec: ## Runs gosec
 	$(GOBIN)/gosec ./...
 
-fulcio: $(SRCS)
-	go build -trimpath -ldflags $(SERVER_LDFLAGS)
+fulcio: $(SRCS) ## Build Fulcio for local tests
+	go build -trimpath -ldflags "$(LDFLAGS)"
 
-test:
+test: ## Runs go test
 	go test ./...
 
-clean:
+clean: ## Clean the workspace
 	rm -rf dist
 	rm -rf fulcio
 
-up:
+up: ## Start docker compose
 	docker-compose -f docker-compose.yml build
 	docker-compose -f docker-compose.yml up
 
-debug:
+debug: ## Start docker compose in debug mode
 	docker-compose -f docker-compose.yml -f docker-compose.debug.yml build fulcio-server-debug
 	docker-compose -f docker-compose.yml -f docker-compose.debug.yml up fulcio-server-debug
 
+## --------------------------------------
+## Images with ko
+## --------------------------------------
+
+.PHONY: ko-local
+ko-local:
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	ko publish --base-import-paths --bare \
+		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
+		github.com/sigstore/fulcio
 
 ## --------------------------------------
 ## Modules
@@ -75,12 +87,14 @@ debug:
 modules: ## Runs go mod to ensure modules are up to date.
 	go mod tidy
 
-# --------------------------------------
-## Release
-## --------------------------------------
+##################
+# help
+##################
 
-.PHONY: dist
-dist:
-	mkdir -p dist
-	docker run -it -v $(PWD):/go/src/sigstore/fulcio -w /go/src/sigstore/fulcio golang:1.16.6 /bin/bash -c "GOOS=linux GOARCH=amd64 go build -trimpath -o dist/fulcio-server-linux-amd64"
+help: ## Display help
+	@awk -F ':|##' \
+		'/^[^\t].+?:.*?##/ {\
+			printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
+		}' $(MAKEFILE_LIST) | sort
 
+include release/release.mk

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ ko-local:
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		github.com/sigstore/fulcio
 
+.PHONY: ko-apply
+ko-apply:
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -Bf config/
+
+.PHONY: ko-publish
+ko-publish:
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish .
+
 ## --------------------------------------
 ## Modules
 ## --------------------------------------

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,63 @@
+# Release
+
+This directory contain the files and scripts to run a cosign release.
+
+# Cutting a Fulcio Release
+
+1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
+  - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
+
+You can get a list of pull requests since the last release by substituting in the date of the last release and running:
+
+```
+git log --pretty="* %s" --after="YYYY-MM-DD"
+```
+
+and a list of authors by running:
+
+```
+git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
+```
+
+2. Tag the repository
+
+```shell
+$ export RELEASE_TAG=<release version, eg "v1.1.0">
+$ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
+$ git push origin ${RELEASE_TAG}
+```
+
+3. Submit the cloudbuild Job using the following command:
+
+```shell
+$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
+   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME> \
+   --project <GCP_PROJECT>
+```
+
+Where:
+
+- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
+- `GCP_PROJECT` is the GCP project where we will run the job.
+- `_GIT_TAG` is the release version we are publishing, this will also create the GitHub Tag.
+- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
+- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
+- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
+- `_KEY_RING` key ring name of your cosign key.
+- `_KEY_NAME` key name of your  cosign key.
+- `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
+- `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
+
+4. When the job finish, whithout issues, you should be able to see in GitHub a draft release.
+You now can review the release, make any changes if needed and then publish to make it an official release.
+
+5. Send an annoucement email to `sigstore-dev@googlegroups.com` mailling list
+
+6. Tweet about the new release with a fun new trigonometry pun!
+
+7. Honk!
+
+#### After the release:
+
+* Add a pending new section in CHANGELOG.md to set up for the next release
+* Create a new GitHub Milestone

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -1,0 +1,120 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+
+steps:
+- name: gcr.io/cloud-builders/git
+  dir: "go/src/sigstore"
+  args:
+  - "clone"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: gcr.io/cloud-builders/git
+  entrypoint: "bash"
+  dir: "go/src/sigstore/fulcio"
+  args:
+  - '-c'
+  - |
+    git fetch
+    echo "Checking out ${_GIT_TAG}"
+    git checkout ${_GIT_TAG}
+
+- name: 'gcr.io/projectsigstore/cosign:v1.4.1@sha256:502d5130431e45f28c51d2c24a05ef5ccd3fd916bcc91db0c8bee3a81e09a0bb'
+  dir: "go/src/sigstore/fulcio"
+  env:
+  - COSIGN_EXPERIMENTAL=true
+  - TUF_ROOT=/tmp
+  args:
+  - 'verify'
+  - '--key'
+  - 'https://raw.githubusercontent.com/gythialy/golang-cross/main/cosign.pub'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.6-1@sha256:f9a94f9dcc1b1396e3b64725cd5333cf9d4e3e05487bf524ecf9e43989244743'
+
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-1@sha256:f9a94f9dcc1b1396e3b64725cd5333cf9d4e3e05487bf524ecf9e43989244743
+  entrypoint: /bin/sh
+  dir: "go/src/sigstore/fulcio"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - KEY_LOCATION=${_KEY_LOCATION}
+  - KEY_RING=${_KEY_RING}
+  - KEY_NAME=${_KEY_NAME}
+  - KEY_VERSION=${_KEY_VERSION}
+  - GIT_TAG=${_GIT_TAG}
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
+  - COSIGN_EXPERIMENTAL=true
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      make release
+
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-1@sha256:f9a94f9dcc1b1396e3b64725cd5333cf9d4e3e05487bf524ecf9e43989244743
+  entrypoint: 'bash'
+  dir: "go/src/sigstore/fulcio"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - KEY_LOCATION=${_KEY_LOCATION}
+  - KEY_RING=${_KEY_RING}
+  - KEY_NAME=${_KEY_NAME}
+  - KEY_VERSION=${_KEY_VERSION}
+  - GIT_TAG=${_GIT_TAG}
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
+  - COSIGN_EXPERIMENTAL=true
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      gcloud auth configure-docker \
+      && make sign-container-release \
+      && make sign-keyless-release
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_NUMBER}/secrets/GITHUB_TOKEN/versions/latest
+    env: GITHUB_TOKEN
+
+artifacts:
+  objects:
+    location: 'gs://${_STORAGE_LOCATION}/${_GIT_TAG}'
+    paths:
+    - "go/src/sigstore/fulcio/dist/fulcio*"
+    - "go/src/sigstore/fulcio/release/release-cosign.pub"
+
+options:
+  machineType: E2_HIGHCPU_8
+
+tags:
+- fulcio-release
+- ${_GIT_TAG}
+- ${_TOOL_ORG}
+- ${_TOOL_REPO}
+
+substitutions:
+  _GIT_TAG: 'v0.0.0'
+  _TOOL_ORG: 'honk'
+  _TOOL_REPO: 'honk-repo'
+  _STORAGE_LOCATION: 'honk'
+  _KEY_RING: 'honk-ring'
+  _KEY_NAME: 'honk-crypto'
+  _KEY_VERSION: '1'
+  _KEY_LOCATION: 'global'

--- a/release/release-cosign.pub
+++ b/release/release-cosign.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhyQCx0E9wQWSFI9ULGwy3BuRklnt
+IqozONbbdbqz11hlRJy9c7SG+hdcFl9jE9uE/dwtuwU2MqU9T/cN0YkWww==
+-----END PUBLIC KEY-----

--- a/release/release.mk
+++ b/release/release.mk
@@ -1,0 +1,85 @@
+##################
+# release section
+##################
+
+# used when releasing together with GCP CloudBuild
+.PHONY: release
+release:
+	LDFLAGS="$(LDFLAGS)" goreleaser release
+
+# used when need to validate the goreleaser
+.PHONY: snapshot
+snapshot:
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist
+
+
+##################
+# images section
+##################
+
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+
+.PHONY: ko-release
+ko-release:
+# amd64
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	ko publish --base-import-paths --bare \
+		--platform=linux/amd64 --tags $(GIT_VERSION)-amd64 --tags $(GIT_HASH)-amd64 \
+		github.com/sigstore/fulcio
+
+# arm64
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	CC=aarch64-linux-gnu-gcc \
+	ko publish --base-import-paths --bare \
+		--platform=linux/arm64 --tags $(GIT_VERSION)-arm64 --tags $(GIT_HASH)-arm64 \
+		github.com/sigstore/fulcio
+
+# arm
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	CC=arm-linux-gnueabihf-gcc \
+	ko publish --base-import-paths --bare \
+		--platform=linux/arm --tags $(GIT_VERSION)-arm --tags $(GIT_HASH)-arm \
+		github.com/sigstore/fulcio
+
+# ppc64le
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	CC=powerpc64le-linux-gnu-gcc \
+	ko publish --base-import-paths --bare \
+		--platform=linux/ppc64le --tags $(GIT_VERSION)-ppc64le --tags $(GIT_HASH)-ppc64le \
+		github.com/sigstore/fulcio
+
+# s390x
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	CC=s390x-linux-gnu-gcc \
+	ko publish --base-import-paths --bare \
+		--platform=linux/s390x --tags $(GIT_VERSION)-s390x --tags $(GIT_HASH)-s390x \
+		github.com/sigstore/fulcio
+
+.PHONY: push-manifest
+push-manifest:
+	docker manifest create --amend $(KO_PREFIX)/fulcio:$(GIT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(KO_PREFIX)/fulcio:$(GIT_VERSION)\-&~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${KO_PREFIX}/fulcio:${GIT_VERSION} ${KO_PREFIX}/fulcio:${GIT_VERSION}-$${arch}; done
+	docker manifest push --purge ${KO_PREFIX}/fulcio:${GIT_VERSION}
+
+	docker manifest create --amend $(KO_PREFIX)/fulcio:$(GIT_HASH) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(KO_PREFIX)/fulcio:$(GIT_HASH)\-&~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${KO_PREFIX}/fulcio:${GIT_HASH} ${KO_PREFIX}/fulcio:${GIT_HASH}-$${arch}; done
+	docker manifest push --purge ${KO_PREFIX}/fulcio:${GIT_HASH}
+
+.PHONY: release-images
+release-images: ko-release push-manifest
+
+###########################
+# sign with GCP KMS section
+###########################
+
+.PHONY: sign-container-release
+sign-container-release: release-images
+	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/fulcio:$(GIT_VERSION)
+
+######################
+# sign keyless section
+######################
+
+.PHONY: sign-keyless-release
+sign-keyless-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/fulcio:$(GIT_VERSION)


### PR DESCRIPTION
#### Summary
- similar we do for rekor and cosing this PR adds the release makefile rules to build/release fulcio using GCP Cloudbuild and goreleaser

this also generate the multi arch binaries and images for linux and generate the SBOM using syft together with signing using cosign


### Rehersal 

- https://github.com/cpanato/fulcio/releases/tag/v99.99.99

```console
$ crane manifest gcr.io/cpanato-general/fulcio:v99.99.99                                                                                                                                                                                                                                                                                                                                                                           [68/1418]
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1123,
         "digest": "sha256:773d8139aeff915a0d1c956ea17feab783d091f22e85a634e7054da167e1d479",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1123,
         "digest": "sha256:cf51df9754da648bcd5f38627fe789d44e6db24e39278c2b05b82a2d9db36ef7",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1123,
         "digest": "sha256:5beea4ad3b25febd8437188193c3f179911bc4b29d0866a89986682362df3fac",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1123,
         "digest": "sha256:21f8383e1eb071729dc9783992f7fea9e7643289b6fc85e9faa12f82db7d7686",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1123,
         "digest": "sha256:b16ee2f8728643f947b9ea43ea15f351c27eaabfdddcc1acd3c72132883c5e2b",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```

```console
$ docker run gcr.io/cpanato-general/fulcio:v99.99.99 version
Unable to find image 'gcr.io/cpanato-general/fulcio:v99.99.99' locally
v99.99.99: Pulling from cpanato-general/fulcio
ab2f6dae3b54: Pull complete
9411f38bb959: Pull complete
250c06f7c38e: Pull complete
1eeafa7d35fd: Pull complete
Digest: sha256:37dddafe4ff2539b574670467f17a3754d96d37c7ac09c5a65bc693534cef22e
Status: Downloaded newer image for gcr.io/cpanato-general/fulcio:v99.99.99
GitVersion:    v99.99.99
GitCommit:     ef66c30284850132d7205bc88d832cb7a1606db8
GitTreeState:  clean
BuildDate:     '2022-01-12T13:01:38Z'
GoVersion:     go1.17.6
Compiler:      gc
Platform:      linux/amd64
```


#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
release: add cloudbuild to run the release for fulcio
```
