### PR TITLE
pin github actions by digest instead of tag

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-name: "CodeQL"
+name: CodeQL
 on:
   push:
     branches: [ main ]
@@ -35,14 +35,16 @@ jobs:
         language: [ 'go' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27
       with:
         languages: ${{ matrix.language }}
+
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27
+
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
       - name: Extract version of Go to use
-        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | sed -r 's/^.*://g'| uniq)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
         with:
           go-version: ${{ env.GOVERSION }}
 

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -22,12 +22,14 @@ jobs:
     name: k8s manifest check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
         with:
-          go-version: 1.16.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install kubeval
-        run: go get github.com/instrumenta/kubeval
+        run: go get github.com/instrumenta/kubeval@v0.16.1
       - run: kubeval config/*.yaml
 
   verify-k8s-deployment:
@@ -56,12 +58,14 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/fulcio
 
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
         with:
-          go-version: 1.16.x
+          go-version: ${{ env.GOVERSION }}
 
-      - uses: imjasonh/setup-ko@v0.4
+      - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 #v0.4
 
       - name: Install KinD
         run: |
@@ -283,7 +287,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 #v2.3.1
         with:
           name: logs
           path: /tmp/logs

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,12 +22,14 @@ jobs:
     name: license boilerplate check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
         with:
-          go-version: '1.16'
+          go-version: ${{ env.GOVERSION }}
       - name: Install addlicense
-        run: go install github.com/google/addlicense@latest
+        run: go install github.com/google/addlicense@v1.0.0
       - name: Check license headers
         run: |
           set -e
@@ -38,11 +40,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 #v2.5.2
         timeout-minutes: 5
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
@@ -52,8 +54,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
+        with:
+          go-version: ${{ env.GOVERSION }}
       - name: check-config
         run: |
           set -e

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.6 AS builder
+FROM golang:1.17.6@sha256:8c0269dfae137ae9756875400aa949203fbe3b67bdb000a57d8b3e9213a3798d AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 
@@ -28,7 +28,7 @@ RUN go build -o server main.go
 RUN CGO_ENABLED=1 go build -gcflags "all=-N -l" -o server_debug main.go
 
 # Multi-Stage production build
-FROM golang:1.17.6 as deploy
+FROM golang:1.17.6@sha256:8c0269dfae137ae9756875400aa949203fbe3b67bdb000a57d8b3e9213a3798d as deploy
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/server /usr/local/bin/fulcio-server
@@ -37,7 +37,7 @@ ENTRYPOINT ["/usr/local/bin/fulcio-server", "serve"]
 
 # debug compile options & debugger
 FROM deploy as debug
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
 
 # overwrite server and include debugger
 COPY --from=builder /opt/app-root/src/server_debug /usr/local/bin/fulcio-server

--- a/Dockerfile.ctfe_init
+++ b/Dockerfile.ctfe_init
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.6 AS builder
+FROM golang:1.17.6@sha256:8c0269dfae137ae9756875400aa949203fbe3b67bdb000a57d8b3e9213a3798d AS builder
 
 WORKDIR /root/
 


### PR DESCRIPTION
Addressing https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

data from running `scorecard --show-details --repo=https://github.com/sigstore/fulcio/ --checks Pinned-Dependencies --format json`:

```
{
  "date": "2022-01-12",
  "repo": {
    "name": "github.com/sigstore/fulcio",
    "commit": "d890471d80472171effea2ce5a77941d351d2bbe"
  },
  "scorecard": {
    "version": "61a0124",
    "commit": "61a01244078b61abf5a2cdced8961927661edb8c"
  },
  "score": 2,
  "checks": [
    {
      "details": [
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql-analysis.yml:38",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql-analysis.yml:42",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql-analysis.yml:46",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql-analysis.yml:48",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/main.yml:29",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/main.yml:32",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify-k8s.yml:25",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify-k8s.yml:26",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify-k8s.yml:59",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify-k8s.yml:60",
        "Warn: third-party action not pinned by hash: .github/workflows/verify-k8s.yml:64",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify-k8s.yml:286",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:25",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:26",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:41",
        "Warn: third-party action not pinned by hash: .github/workflows/verify.yml:45",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:55",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:56",
        "Warn: docker image not pinned by hash: Dockerfile:16",
        "Warn: docker image not pinned by hash: Dockerfile:31",
        "Warn: docker image not pinned by hash: Dockerfile:39",
        "Warn: docker image not pinned by hash: Dockerfile.ctfe_init:16",
        "Warn: go installation not pinned by hash: Dockerfile:40",
        "Warn: go installation not pinned by hash: Dockerfile.ctfe_init:20",
        "Info: no insecure (not pinned by hash) dependency downloads found in shell scripts",
        "Warn: go installation not pinned by hash: .github/workflows/verify-k8s.yml:31",
        "Warn: go installation not pinned by hash: .github/workflows/verify.yml:31"
      ],
      "score": 2,
      "reason": "dependency not pinned by hash detected -- score normalized to 2",
      "name": "Pinned-Dependencies",
      "documentation": {
        "url": "https://github.com/ossf/scorecard/blob/61a01244078b61abf5a2cdced8961927661edb8c/docs/checks.md#pinned-dependencies",
        "short": "Determines if the project has declared and pinned its dependencies."
      }
    }
  ],
  "metadata": null
}

```
This also updates references to set a consistent Go version based on the value in `Dockerfile`. 

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
