### PR TITLE
Add some reasonable timeouts to API server

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -206,6 +207,12 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	api := http.Server{
 		Addr:    host + ":" + port,
 		Handler: handler,
+
+		// Timeouts
+		ReadTimeout:       60 * time.Second,
+		ReadHeaderTimeout: 60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	if err := api.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
#### Summary

Adds a 1 minute hard coded read, header read, write and idle timeout. This helps prevents accidental or malicious connection exhaustion of the API server.

_Implementation note_

While simply setting `ReadTimeout` would have set the header read and write timeouts to the same value, I think setting them explicitly helps inform the future code readers about the server behaviour in case they're unfamiliar with the behaviour of `http.Server` timeouts.

#### Ticket Link

Fixes #336

#### Release Note

```release-note
* Added 1 minute read, write and idle timeouts to API server
```
