### PR TITLE
Add chain in response for all CAs, fix newlines in response

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -242,8 +242,8 @@ func fakeCTLogServer(t *testing.T) *httptest.Server {
 		}
 		var chain certChain
 		json.Unmarshal(body, &chain)
-		if len(chain.Chain) != 1 {
-			t.Fatalf("Did not get expected chain for input, wanted 1 entry, got %d", len(chain.Chain))
+		if len(chain.Chain) != 2 {
+			t.Fatalf("Did not get expected chain for input, wanted 2 entries, got %d", len(chain.Chain))
 		}
 		// Just make sure we can decode it.
 		for _, chainEntry := range chain.Chain {

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -196,14 +196,21 @@ func signingCert(w http.ResponseWriter, req *http.Request) {
 		handleFulcioAPIError(w, req, http.StatusInternalServerError, err, failedToMarshalCert)
 		return
 	}
-	fmt.Fprintf(&ret, "%s\n", finalPEM)
+	fmt.Fprintf(&ret, "%s", finalPEM)
+	if finalPEM[len(finalPEM)-1] != '\n' {
+		fmt.Fprintf(&ret, "\n")
+	}
+
 	finalChainPEM, err := csc.ChainPEM()
 	if err != nil {
 		handleFulcioAPIError(w, req, http.StatusInternalServerError, err, failedToMarshalCert)
 		return
 	}
 	if len(finalChainPEM) > 0 {
-		fmt.Fprintf(&ret, "%s\n", finalChainPEM)
+		fmt.Fprintf(&ret, "%s", finalChainPEM)
+		if finalPEM[len(finalChainPEM)-1] != '\n' {
+			fmt.Fprintf(&ret, "\n")
+		}
 	}
 
 	// Set the SCT and Content-Type headers, and then respond with a 201 Created.

--- a/pkg/ca/fileca/fileca.go
+++ b/pkg/ca/fileca/fileca.go
@@ -99,7 +99,7 @@ func (fca *fileCA) CreateCertificate(_ context.Context, subject *challenges.Chal
 		return nil, err
 	}
 
-	return ca.CreateCSCFromDER(subject, finalCertBytes, nil)
+	return ca.CreateCSCFromDER(subject, finalCertBytes, fca.certs)
 }
 
 func (fca *fileCA) Root(ctx context.Context) ([]byte, error) {

--- a/pkg/ca/interface.go
+++ b/pkg/ca/interface.go
@@ -63,7 +63,7 @@ func CreateCSCFromPEM(subject *challenges.ChallengeResult, cert string, chain []
 	return c, nil
 }
 
-func CreateCSCFromDER(subject *challenges.ChallengeResult, cert, chain []byte) (c *CodeSigningCertificate, err error) {
+func CreateCSCFromDER(subject *challenges.ChallengeResult, cert []byte, chain []*x509.Certificate) (c *CodeSigningCertificate, err error) {
 	c = &CodeSigningCertificate{
 		Subject: subject,
 	}
@@ -76,14 +76,14 @@ func CreateCSCFromDER(subject *challenges.ChallengeResult, cert, chain []byte) (
 	}
 
 	// convert to X509 and store both formats
-	c.FinalChain, err = x509.ParseCertificates(chain)
+	c.FinalChain = chain
 	if err != nil {
 		return nil, err
 	}
 	buf := bytes.Buffer{}
-	for i, chainCert := range c.FinalChain {
+	for _, chainCert := range c.FinalChain {
 		buf.Write(cryptoutils.PEMEncode(cryptoutils.CertificatePEMType, chainCert.Raw))
-		if i != len(c.FinalChain) {
+		if chainCert.Raw[len(chainCert.Raw)-1] != '\n' {
 			buf.WriteRune('\n')
 		}
 	}

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -96,7 +96,7 @@ func (x *X509CA) CreateCertificate(_ context.Context, subject *challenges.Challe
 		return nil, err
 	}
 
-	return ca.CreateCSCFromDER(subject, finalCertBytes, nil)
+	return ca.CreateCSCFromDER(subject, finalCertBytes, []*x509.Certificate{x.RootCA})
 }
 
 func AdditionalExtensions(subject *challenges.ChallengeResult) []pkix.Extension {


### PR DESCRIPTION
The certificate's chain was not being included when issuing
certificates for non-GCP CAs.

We were also adding too many newlines between PEM-encoded
certificates. pem.Encode automatically adds newlines. Just
in case the source that's providing the certificates is
not including trailing newlines, I've added a check to
optionally append newlines. The `dev.sigstore.cosign/chain`
annotation will no longer start with a newline after this change.

I've tested these changes with a local instance of Fulcio, and
there were no issues with Cosign signing and verifying.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
