### PR TITLE
Deprecate gcp_private_ca_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The public Fulcio root CA is currently running on [GCP CA Service](https://cloud
 You can also run Fulcio with your own CA on CA Service by passing in a parent and specifying Google as the CA:
 
 ```
-go run main.go serve --ca googleca  --gcp_private_ca_parent=projects/myproject/locations/us-central1/caPools/mypool --gcp_private_ca_version=v1
+go run main.go serve --ca googleca  --gcp_private_ca_parent=projects/myproject/locations/us-central1/caPools/mypool
 ```
 
 ### PKCS11CA

--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -59,7 +59,6 @@ data:
         host: 0.0.0.0
         port: 5555
         ca: googleca
-        gcp_private_ca_version: v1
         ct-log-url: http://ct-log/test
         log_type: prod
 kind: ConfigMap


### PR DESCRIPTION
Towards #342: remove v1beta1 GCP CA API.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Deprecated config option `gcp_private_ca_version` (please omit)
```
