### PR TITLE
Initialize CT log client once

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -85,9 +85,9 @@ func TestAPI(t *testing.T) {
 	if ctlogServer == nil {
 		t.Fatalf("Failed to create the fake ctlog server")
 	}
-	ctlogURL := ctlogServer.URL
+
 	// Create a test HTTP server to host our API.
-	h := NewHandler()
+	h := New(ctl.New(ctlogServer.URL))
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		// For each request, infuse context with our snapshot of the FulcioConfig.
@@ -95,7 +95,6 @@ func TestAPI(t *testing.T) {
 
 		// Decorate the context with our CA for testing.
 		ctx = WithCA(ctx, eca)
-		ctx = WithCTLogURL(ctx, ctlogURL)
 
 		h.ServeHTTP(rw, r.WithContext(ctx))
 	}))

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -26,7 +26,7 @@ const (
 	invalidSignature          = "The signature supplied in the request could not be verified"
 	invalidCertificateRequest = "The CertificateRequest was invalid"
 	invalidPublicKey          = "The public key supplied in the request could not be parsed"
-	failedToEnterCertInCTL    = "Error entering certificate in CTL @ '%v'"
+	failedToEnterCertInCTL    = "Error entering certificate in CTL"
 	failedToMarshalSCT        = "Error marshaling signed certificate timestamp"
 	failedToMarshalCert       = "Error marshaling code signing certificate"
 	//nolint


### PR DESCRIPTION
This work initializes the CT log client once and uses it for all requests instead of making a new one each time.

**Thoughts for reviewers**

The implementation here breaks from our current pattern of injecting dependencies by stuffing them into the request context. I think that explicit dependency inject makes it easier to reason about and test the code. This looks like explicitly asking for the API dependencies on construction and saving them in a struct so they can be accessed like that instead of pulling them out of the request context.

If ya'll agree that this pattern is more clear, I'm happy to iterate and do the same for the other API dependencies like the certificate authority backend and perhaps the logger. If not I'm happy to close this PR and fix using the context stuffing method instead.

#### Release Note

```release-note
* Reuses the CT log client for all API requests instead of making a new client each time
```
