### PR TITLE
createca: Address panic when no private key pair matches

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -94,10 +94,14 @@ func runCreateCACmd(cmd *cobra.Command, args []string) {
 
 	// Find the existing Key Pair
 	// TODO: We could make the TAG customizable
-	log.Logger.Info("finding slot for private key: ", LABEL)
+	log.Logger.Infof("finding slot for private key label %q", LABEL)
 	privKey, err := p11Ctx.FindKeyPair(nil, []byte(LABEL))
 	if err != nil {
 		log.Logger.Fatal(err)
+	}
+
+	if privKey == nil {
+		log.Logger.Fatalf("no key pair was found matching label %q", LABEL)
 	}
 
 	pubKey := privKey.Public()
@@ -164,7 +168,8 @@ func runCreateCACmd(cmd *cobra.Command, args []string) {
 		}
 		if err := pem.Encode(certOut, &pem.Block{ //nolint
 			Type:  "CERTIFICATE",
-			Bytes: caBytes},
+			Bytes: caBytes,
+		},
 		); err != nil {
 			certOut.Close()
 			log.Logger.Fatal(err)

--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -168,8 +168,7 @@ func runCreateCACmd(cmd *cobra.Command, args []string) {
 		}
 		if err := pem.Encode(certOut, &pem.Block{ //nolint
 			Type:  "CERTIFICATE",
-			Bytes: caBytes,
-		},
+			Bytes: caBytes},
 		); err != nil {
 			certOut.Close()
 			log.Logger.Fatal(err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

While following https://github.com/lukehinds/sigstore-the-hard-way - I managed to trigger a panic by running:

`go run . createca --org=acme --country=USA --locality=Anytown --province=AnyPlace --postal-code=ABCDEF --street-address=123 Main St --hsm-caroot-id 0 --out fulcio-root.pem`

which resulted in the following output:

```shell
INFO	app/createca.go:77	binding to PKCS11 HSM
INFO	app/createca.go:97	finding slot for private key: PKCS11CA
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1222616]

goroutine 1 [running]:
github.com/sigstore/fulcio/cmd/app.runCreateCACmd(0xc0001fb680, {0xc0000a6a80, 0x2, 0xc})
	/home/t/src/fulcio.up/cmd/app/createca.go:103 +0x616
github.com/spf13/cobra.(*Command).execute(0xc0001fb680, {0xc0000a69c0, 0xc, 0xc})
	/home/t/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:860 +0x8b3
...
```

I wasn't sure how to interpret this, so I dove into the source code and discovered that PKCS11CA was a label, rather than a key type or format. Apparently, the tutorial uses a label of "FulcioCA", whereas fulcio expected "PKCS11CA" (this may just be a HEAD vs latest release change).

This PR catches the unhandled panic and makes the underlying issue a little bit more clear:

```shell
go run . createca --org=acme --country=USA --locality=Anytown --province=AnyPlace --postal-code=ABCDEF --street-address=123 Main St --hsm-caroot-id 0 --out fulcio-root.pem
INFO       app/createca.go:77      binding to PKCS11 HSM
INFO       app/createca.go:97      finding slot for private key label "PKCS11CA"
FATAL      app/createca.go:104     no key pair was found matching label "PKCS11CA"
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
createca: Address panic when no private key pair matches
```
