### PR TITLE
Move CTL logging logic over to CTL package

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -174,6 +174,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	var ctClient ctl.Client
 	if logURL := viper.GetString("ct-log-url"); logURL != "" {
 		ctClient = ctl.New(logURL)
+		ctClient = ctl.WithLogging(ctClient, log.Logger)
 	}
 
 	var handler http.Handler

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -171,7 +171,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	host, port := viper.GetString("host"), viper.GetString("port")
 	log.Logger.Infof("%s:%s", host, port)
 
-	var ctClient *ctl.Client
+	var ctClient ctl.Client
 	if logURL := viper.GetString("ct-log-url"); logURL != "" {
 		ctClient = ctl.New(logURL)
 	}

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -174,7 +174,6 @@ func (a *api) signingCert(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// Submit to CTL
-		logger.Info("Submitting CTL inclusion for OIDC grant: ", subject.Value)
 		if a.ct != nil {
 			sct, err := a.ct.AddChain(csc)
 			if err != nil {
@@ -186,8 +185,6 @@ func (a *api) signingCert(w http.ResponseWriter, req *http.Request) {
 				handleFulcioAPIError(w, req, http.StatusInternalServerError, err, failedToMarshalSCT)
 				return
 			}
-			logger.Info("CTL Submission Signature Received: ", sct.Signature)
-			logger.Info("CTL Submission ID Received: ", sct.ID)
 		} else {
 			logger.Info("Skipping CT log upload.")
 		}

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -54,14 +54,14 @@ const (
 )
 
 type api struct {
-	ct *ctl.Client
+	ct ctl.Client
 	ca certauth.CertificateAuthority
 
 	*http.ServeMux
 }
 
 // New creates a new http.Handler for serving the Fulcio API.
-func New(ct *ctl.Client, ca certauth.CertificateAuthority) http.Handler {
+func New(ct ctl.Client, ca certauth.CertificateAuthority) http.Handler {
 	var a api
 	a.ServeMux = http.NewServeMux()
 	a.HandleFunc(signingCertPath, a.signingCert)

--- a/pkg/ctl/client.go
+++ b/pkg/ctl/client.go
@@ -28,14 +28,14 @@ import (
 
 const addChainPath = "ct/v1/add-chain"
 
-type Client struct {
+type client struct {
 	c   *http.Client
 	url string
 }
 
-func New(url string) *Client {
+func New(url string) Client {
 	c := &http.Client{Timeout: 30 * time.Second}
-	return &Client{
+	return &client{
 		c:   c,
 		url: url,
 	}
@@ -53,20 +53,7 @@ type CertChainResponse struct {
 	Signature  string `json:"signature"`
 }
 
-type ErrorResponse struct {
-	StatusCode int    `json:"statusCode"`
-	ErrorCode  string `json:"errorCode"`
-	Message    string `json:"message"`
-}
-
-func (err *ErrorResponse) Error() string {
-	if err.ErrorCode == "" {
-		return fmt.Sprintf("%d CT API error: %s", err.StatusCode, err.Message)
-	}
-	return fmt.Sprintf("%d (%s) CT API error: %s", err.StatusCode, err.ErrorCode, err.Message)
-}
-
-func (c *Client) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
+func (c *client) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
 	chainjson := &certChain{Chain: []string{
 		base64.StdEncoding.EncodeToString(csc.FinalCertificate.Raw),
 	}}

--- a/pkg/ctl/client_test.go
+++ b/pkg/ctl/client_test.go
@@ -47,7 +47,7 @@ func Test_AddChain(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api := Client{server.Client(), server.URL}
+	api := New(server.URL)
 	csc, _ := ca.CreateCSCFromPEM(nil, rootCert, clientCert)
 	body, err := api.AddChain(csc)
 	assert.NoError(t, err)

--- a/pkg/ctl/ctl_logging.go
+++ b/pkg/ctl/ctl_logging.go
@@ -20,12 +20,12 @@ import (
 	"go.uber.org/zap"
 )
 
-type loggingClient struct {
+type ctlLoggingClient struct {
 	next   Client
 	logger *zap.SugaredLogger
 }
 
-func (lc *loggingClient) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
+func (lc *ctlLoggingClient) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
 	lc.logger.Info("Submitting CTL inclusion for subject", csc.Subject.Value)
 	resp, err := lc.next.AddChain(csc)
 	if err != nil {
@@ -37,7 +37,8 @@ func (lc *loggingClient) AddChain(csc *ca.CodeSigningCertificate) (*CertChainRes
 	return resp, nil
 }
 
-// WithLogging adds logging to a certificate transparenct log client
+// WithLogging adds logging (in the writing helpful information to console
+// sense) to a certificate transparenct log client
 func WithLogging(next Client, logger *zap.SugaredLogger) Client {
-	return &loggingClient{next, logger}
+	return &ctlLoggingClient{next, logger}
 }

--- a/pkg/ctl/ctl_logging_test.go
+++ b/pkg/ctl/ctl_logging_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctl
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/sigstore/fulcio/pkg/ca"
+	"github.com/sigstore/fulcio/pkg/challenges"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type clientFunc func(csc *ca.CodeSigningCertificate) (*CertChainResponse, error)
+
+func (f clientFunc) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
+	return f(csc)
+}
+
+func TestWithLogging(t *testing.T) {
+	tests := map[string]struct {
+		Client         Client
+		ExpectedOutput *regexp.Regexp
+	}{
+		"Error in client should be logged": {
+			clientFunc(func(*ca.CodeSigningCertificate) (*CertChainResponse, error) {
+				return nil, errors.New(`ctl: testing error`)
+			}),
+			regexp.MustCompile(`ctl: testing error`),
+		},
+		"Success in client should log information": {
+			clientFunc(func(*ca.CodeSigningCertificate) (*CertChainResponse, error) {
+				return &CertChainResponse{}, nil
+			}),
+			regexp.MustCompile(`CTL Submission ID Received:`),
+		},
+	}
+
+	for test, data := range tests {
+		t.Run(test, func(t *testing.T) {
+			// Given
+			observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+			observedLogger := zap.New(observedZapCore)
+			client := WithLogging(data.Client, observedLogger.Sugar())
+
+			csc := ca.CodeSigningCertificate{
+				Subject: &challenges.ChallengeResult{},
+			}
+
+			// When
+			_, _ = client.AddChain(&csc)
+
+			// Then
+			for _, entry := range observedLogs.All() {
+				if data.ExpectedOutput.MatchString(entry.Message) {
+					// We received expected output so the test passes
+					return
+				}
+			}
+			// If we got here we didn't match the expected output so test fails
+			t.Error("Didn't find expected output in logs")
+		})
+	}
+}

--- a/pkg/ctl/errorresponse.go
+++ b/pkg/ctl/errorresponse.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ctl
+
+import "fmt"
+
+type ErrorResponse struct {
+	StatusCode int    `json:"statusCode"`
+	ErrorCode  string `json:"errorCode"`
+	Message    string `json:"message"`
+}
+
+func (err *ErrorResponse) Error() string {
+	if err.ErrorCode == "" {
+		return fmt.Sprintf("%d CT API error: %s", err.StatusCode, err.Message)
+	}
+	return fmt.Sprintf("%d (%s) CT API error: %s", err.StatusCode, err.ErrorCode, err.Message)
+}

--- a/pkg/ctl/interface.go
+++ b/pkg/ctl/interface.go
@@ -1,0 +1,22 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ctl
+
+import "github.com/sigstore/fulcio/pkg/ca"
+
+type Client interface {
+	AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error)
+}

--- a/pkg/ctl/logging.go
+++ b/pkg/ctl/logging.go
@@ -1,0 +1,43 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ctl
+
+import (
+	"github.com/sigstore/fulcio/pkg/ca"
+	"go.uber.org/zap"
+)
+
+type loggingClient struct {
+	next   Client
+	logger *zap.SugaredLogger
+}
+
+func (lc *loggingClient) AddChain(csc *ca.CodeSigningCertificate) (*CertChainResponse, error) {
+	lc.logger.Info("Submitting CTL inclusion for subject", csc.Subject.Value)
+	resp, err := lc.next.AddChain(csc)
+	if err != nil {
+		lc.logger.Error("Failed to submit certificate to CTL with error", err)
+		return nil, err
+	}
+	lc.logger.Info("CTL Submission Signature Received: ", resp.Signature)
+	lc.logger.Info("CTL Submission ID Received: ", resp.ID)
+	return resp, nil
+}
+
+// WithLogging adds logging to a certificate transparenct log client
+func WithLogging(next Client, logger *zap.SugaredLogger) Client {
+	return &loggingClient{next, logger}
+}


### PR DESCRIPTION
#### Summary

In an attempt to de-cluster the all powerful `api.(*api).signingCert` method, I've moved to logging logic for the CT log client over into the CT log package. This is achieved by

- Abstracting the CTL client into an interface
- Creating a `ctl.WithLogging(inner ctl.Client, logger *Logger) ctl.Client` middleware to instrument the client
- Finally removing the logging from the `signingCert` method

#### Release Note

```release-note
NONE
```
