### PR TITLE
Make CA explicit dependency of API handler

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -177,7 +177,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 
 	var handler http.Handler
 	{
-		handler = api.New(ctClient)
+		handler = api.New(ctClient, baseca)
 
 		// Inject dependencies
 		withDependencies := func(inner http.Handler) http.Handler {
@@ -189,7 +189,6 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 				// from disk, so that we don't need to cycle pods to pick up config updates.
 				// Alternately we could take advantage of Knative's configmap watcher.
 				ctx = config.With(ctx, cfg)
-				ctx = api.WithCA(ctx, baseca)
 
 				inner.ServeHTTP(rw, r.WithContext(ctx))
 			})

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -87,14 +87,11 @@ func TestAPI(t *testing.T) {
 	}
 
 	// Create a test HTTP server to host our API.
-	h := New(ctl.New(ctlogServer.URL))
+	h := New(ctl.New(ctlogServer.URL), eca)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		// For each request, infuse context with our snapshot of the FulcioConfig.
 		ctx = config.With(ctx, cfg)
-
-		// Decorate the context with our CA for testing.
-		ctx = WithCA(ctx, eca)
 
 		h.ServeHTTP(rw, r.WithContext(ctx))
 	}))


### PR DESCRIPTION
#### Summary

Small refactor to make the CA an explicit dependency of the API handler instead of stuffing it in the request context

#### Release Note

```release-note
NONE
```
