### PR TITLE
Make the the invalid CA error message actionable

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -116,7 +116,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	case "ephemeralca":
 		// this is a no-op since this is a self-signed in-memory CA for testing
 	default:
-		log.Logger.Fatal("unknown CA: ", viper.GetString("ca"))
+		log.Logger.Fatalf("--ca=%s is not a valid selection. Try: pkcs11ca, googleca, fileca, or ephemeralca", viper.GetString("ca"))
 	}
 
 	// Setup the logger to dev/prod


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@chainguard.dev>

#### Summary

This PR improves the error message when an invalid `--ca` is provided by making it directly actionable. This lowers the friction for folks like me who are blindly pasting lines from the sigstore-the-hard-way doc. 

When I first saw the error message, it did not occur to me that it referenced the `--ca` value versus an expected value within the key pair. Here is the example command-line to trigger the condition:

`fulcio serve --config-path=fulcio-config.json --ca=fulcioca --hsm-caroot-id=1 --ct-log-url=http://localhost:6105/sigstore --host=0.0.0.0 --port=5000`

**Old output**

`FATAL	app/serve.go:119	unknown CA: fulcioca`

**New output**

`FATAL	app/serve.go:119	--ca=fulcioca is not a valid selection. Try: pkcs11ca, googleca, fileca, or ephemeralca`

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
