### PR TITLE
Improve error message when an invalid OIDC issuer is provided

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -125,9 +125,10 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	// from https://github.com/golang/glog/commit/fca8c8854093a154ff1eb580aae10276ad6b1b5f
 	_ = flag.CommandLine.Parse([]string{})
 
-	cfg, err := config.Load(viper.GetString("config-path"))
+	cp := viper.GetString("config-path")
+	cfg, err := config.Load(cp)
 	if err != nil {
-		log.Logger.Fatalf("error loading config: %v", err)
+		log.Logger.Fatalf("error loading --config-path=%s: %v", cp, err)
 	}
 
 	var baseca certauth.CertificateAuthority


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@chainguard.dev>

#### Summary

This PR improves the error message output when the OIDC Issuer URL is not valid. For example, with this command-line: `fulcio serve --ca=pkcs11ca --hsm-caroot-id=1 --ct-log-url=http://localhost:6105/sigstore --host=0.0.0.0 --port=5000`

## Old output

`FATAL	app/serve.go:130	error loading config: 404 Not Found: 404 page not found`

## New output

`FATAL	app/serve.go:131	error loading --config-path=/etc/fulcio-config/config.json: provider http://localhost:5556/auth: 404 Not Found: 404 page not found`


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```