### PR TITLE
Address signingCert panic with the last-byte calculation of finalChainPEM

### DIFF
--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -213,7 +213,7 @@ func (a *api) signingCert(w http.ResponseWriter, req *http.Request) {
 	}
 	if len(finalChainPEM) > 0 {
 		fmt.Fprintf(&ret, "%s", finalChainPEM)
-		if finalPEM[len(finalChainPEM)-1] != '\n' {
+		if finalChainPEM[len(finalChainPEM)-1] != '\n' {
 			fmt.Fprintf(&ret, "\n")
 		}
 	}

--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -16,6 +16,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/x509"
@@ -202,7 +203,7 @@ func (a *api) signingCert(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	fmt.Fprintf(&ret, "%s", finalPEM)
-	if finalPEM[len(finalPEM)-1] != '\n' {
+	if !bytes.HasSuffix(finalPEM, []byte("\n")) {
 		fmt.Fprintf(&ret, "\n")
 	}
 
@@ -213,7 +214,7 @@ func (a *api) signingCert(w http.ResponseWriter, req *http.Request) {
 	}
 	if len(finalChainPEM) > 0 {
 		fmt.Fprintf(&ret, "%s", finalChainPEM)
-		if finalChainPEM[len(finalChainPEM)-1] != '\n' {
+		if !bytes.HasSuffix(finalChainPEM, []byte("\n")) {
 			fmt.Fprintf(&ret, "\n")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

Addresses a panic caused by the incorrect string being referred for a newline check.

This panic only occurs if finalPEM is shorter than finalChainPEM.

#### Ticket Link

Fixes #369

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
