### PR TITLE
Allow parameterized application/json content types

### DIFF
--- a/pkg/api/ca_test.go
+++ b/pkg/api/ca_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import "testing"
+
+func TestVerifyContentType(t *testing.T) {
+	testCases := []struct {
+		contentType string
+		shouldPass  bool
+	}{
+		{"application/json", true},
+		{"application/json; charset=UTF-8", true},
+		{"application/unsupported", false},
+		{"some nonsense", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.contentType, func(t *testing.T) {
+			err := verifyContentType(tc.contentType)
+			if err != nil && tc.shouldPass {
+				t.Fatalf("Expected no error but got %q", err)
+			}
+			if err == nil && !tc.shouldPass {
+				t.Fatalf("Expected error but got none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes a compatibility issue where content-type "application/json; charset=UTF-8" wasn't allowed.
