### PR TITLE
Improve error messages returned by SigningCert

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -81,12 +82,12 @@ func (c *client) SigningCert(cr CertificateRequest, token string) (*CertificateR
 
 	b, err := json.Marshal(cr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshal: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewBuffer(b))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("request: %w", err)
 	}
 	// Set the authorization header to our OIDC bearer token.
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -95,25 +96,25 @@ func (c *client) SigningCert(cr CertificateRequest, token string) (*CertificateR
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("client: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s read: %w", endpoint.String(), err)
 	}
 
 	// The API should return a 201 Created on success.  If we see anything else,
 	// then turn the response body into an error.
 	if resp.StatusCode != http.StatusCreated {
-		return nil, errors.New(string(body))
+		return nil, fmt.Errorf("%s %s returned %s: %q", http.MethodPost, endpoint.String(), resp.Status, body)
 	}
 
 	// Extract the SCT from the response header.
 	sct, err := base64.StdEncoding.DecodeString(resp.Header.Get("SCT"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode: %w", err)
 	}
 
 	// Split the cert and the chain


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

This improves error messages returned by SigningCert, specifically adding the URL and status code when an unexpected response code occurs. Currently, if one accidentally points the Fulcio client at a non-Fulcio endpoint, the error message isn't very helpful; particularly when an empty HTTP response body is encountered.

### Previous error message

`retrieving cert:  `


### New error message

`retrieving cert: POST http://localhost:5000/api/v1/signingCert returned 403 Forbidden: ""`

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #387

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
