### PR TITLE
Remove organization from subject for GCP CAS issuer

### DIFF
--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -83,7 +83,6 @@ func convertID(id asn1.ObjectIdentifier) []int32 {
 }
 
 func Req(parent string, pemBytes []byte, cert *x509.Certificate) (*privatecapb.CreateCertificateRequest, error) {
-	// TODO, use the right fields :)
 	pubkeyFormat, err := getPubKeyFormat(pemBytes)
 	if err != nil {
 		return nil, err
@@ -91,9 +90,7 @@ func Req(parent string, pemBytes []byte, cert *x509.Certificate) (*privatecapb.C
 
 	// Translate the x509 certificate's subject to Google proto.
 	subject := &privatecapb.CertificateConfig_SubjectConfig{
-		Subject: &privatecapb.Subject{
-			Organization: "sigstore",
-		},
+		Subject: &privatecapb.Subject{},
 		SubjectAltName: &privatecapb.SubjectAltNames{
 			EmailAddresses: cert.EmailAddresses,
 		},


### PR DESCRIPTION
The fields of the Subject proto do not need to be
specified, but the Subject proto is still required.
This does result in an empty subject when viewing
the certificate in openssl or macOS keychain, but
this is something I'll be filing an issue with CAS for.

Tested by running a local instance of Fulcio with
my own instance of CA Service.

Fixes #390

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #390 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Removed organization from GCP CA Service issued certificates
```
