### PR TITLE
Count HTTP request error codes with prometheus

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -199,7 +199,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 
 		// Instrument Prometheus metrics
 		handler = promhttp.InstrumentHandlerDuration(api.MetricLatency, handler)
-
+		handler = promhttp.InstrumentHandlerCounter(api.RequestsCount, handler)
 		// Limit request size
 		handler = api.WithMaxBytes(handler, 1<<22) // 4MiB
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/coreos/go-oidc/v3 v3.1.0
+	github.com/felixge/httpsnoop v1.0.2
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -30,4 +30,9 @@ var (
 		Name: "fulcio_api_latency",
 		Help: "API Latency on calls",
 	}, []string{"code", "method"})
+
+	RequestsCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Count all HTTP requests",
+	}, []string{"code", "method"})
 )


### PR DESCRIPTION
Part of monitoring for GA! We can count, track and start alerting if error codes start to increase.

Seems like we only have one endpoint at the moment, but it would be nice if that was including in these metrics later on! 