### PR TITLE
Add feature stability and deprecation docs

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,10 @@
+# Deprecations
+
+This doc lists deprecated features in `fulcio`.
+You can read more about Sigstore's deprecation policy [here](https://docs.sigstore.dev/api-stability)!
+
+| **Feature Being Deprecated** | **API Stability Level** | **Earliest Date of Removal** |
+|------------------------------|-------------------------|------------------------------|
+| My feature                   | Experimental/Beta/GA    | DD/MM/YY                     |
+|                              |                         |                              |
+|                              |                         |                              |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,15 @@
+# Feature Stability
+
+This doc covers feature stability in `fulcio` as described in the [API Stability Policy](https://docs.sigstore.dev/api-stability) for Sigstore.
+
+## Experimental
+
+
+## Beta
+* The Fulcio API, defined [here](https://github.com/sigstore/fulcio/blob/main/pkg/api/client.go)
+* Support for various Certificate Authorities (CAs), including Google Private CA Service, PKCS11, and File backed CA
+* Support for SPIFFE challenges and OIDC based email challenges
+* The Go client library defined in `fulcio/pkg`
+* Issuers defined in [fulcio-config.yaml](https://github.com/sigstore/fulcio/blob/main/config/fulcio-config.yaml)
+
+## General Availability


### PR DESCRIPTION
Adding deprecation policy and feature stability docs based on the policy described [here](https://docs.sigstore.dev/api-stability). I guessed at the most important features to include, but let me know if I'm missing anything!

I put everything in `beta` right now because Fulcio isn't 1.0, but happy to move features to other sections if that's more accurate.


Ref https://github.com/sigstore/sigstore-website/issues/119

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

