### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,54 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+        description: 'Release tag'
+      key_ring:
+        required: true
+        type: string
+        description: 'Key ring for cosign key'
+      key_name:
+        required: true
+        type: string
+        description: 'Key name for cosign key'
+
+concurrency: cut-release
+
+jobs:
+  cut-release:
+    name: Cut release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      GIT_TAG: ${{ github.event.inputs.release_tag }}
+      PROJECT_ID: 'projectsigstore'
+    steps:
+      - name: Check actor access
+        if: ${{ !contains(fromJson('["bobcallaway","cpanato","dlorenc","lukehinds"]'), github.actor) }}
+        run: exit 1
+
+      - name: Checkout out repo
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/sigstore/fulcio
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-fulcio'
+          service_account: 'github-actions-fulcio@projectsigstore.iam.gserviceaccount.com'
+
+      - name: Setup gcloud
+        uses: 'google-github-actions/setup-gcloud@v0'
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Start cloudbuild job
+        working-directory: ./src/github.com/sigstore/fulcio
+        run: gcloud builds submit --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }} --project=${{ env.PROJECT_ID }}

--- a/hack/github-oidc-setup.sh
+++ b/hack/github-oidc-setup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Idempotent script.
+#
+# Commands based off of Google blog post
+# https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions
+#
+# One addition is the attribute.repository=assertion.repository mapping.
+# This allows it to be pinned to given repo.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o verbose
+set -o xtrace
+
+PROJECT_ID="projectsigstore"
+PROJECT_NUMBER="498091336538"
+POOL_NAME="githubactions"
+PROVIDER_NAME="sigstore-fulcio"
+LOCATION="global"
+REPO="sigstore/fulcio"
+SERVICE_ACCOUNT_ID="github-actions-fulcio"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Create workload identity pool if not present.
+if ! (gcloud iam workload-identity-pools describe "${POOL_NAME}" --location=${LOCATION}); then
+  gcloud iam workload-identity-pools create "${POOL_NAME}" \
+    --project="${PROJECT_ID}" \
+    --location="${LOCATION}" \
+    --display-name="Github Actions Pool"
+fi
+
+# Create workload identity provider if not present.
+if ! (gcloud iam workload-identity-pools providers describe "${PROVIDER_NAME}" --location="${LOCATION}" --workload-identity-pool="${POOL_NAME}"); then
+  gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_NAME}" \
+  --project="${PROJECT_ID}" \
+  --location="${LOCATION}" \
+  --workload-identity-pool="${POOL_NAME}" \
+  --display-name="Github Actions Provider Fulcio" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.aud=assertion.aud,attribute.repository=assertion.repository" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+fi
+
+# Create service account if not present.
+if ! (gcloud iam service-accounts describe "${SERVICE_ACCOUNT}"); then
+gcloud iam service-accounts create ${SERVICE_ACCOUNT_ID} \
+  --description="Service account for Github Actions Fulcio" \
+  --display-name="Github Actions Fulcio"
+fi
+
+# Adding binding is idempotent.
+gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/${LOCATION}/workloadIdentityPools/${POOL_NAME}/attribute.repository/${REPO}"

--- a/release/README.md
+++ b/release/README.md
@@ -2,51 +2,90 @@
 
 This directory contain the files and scripts to run a cosign release.
 
-# Cutting a Fulcio Release
+# Cutting a Fulcio Release [workflow]
 
 1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
   - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
 
-You can get a list of pull requests since the last release by substituting in the date of the last release and running:
+  You can get a list of pull requests since the last release by substituting in the date of the last release and running:
 
-```
-git log --pretty="* %s" --after="YYYY-MM-DD"
-```
+	```
+	git log --pretty="* %s" --after="YYYY-MM-DD"
+	```
+	
+	and a list of authors by running:
+	
+	```
+	git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
+	```
 
-and a list of authors by running:
+2. Run "Cut Release" workflow
+	- Open the "Actions" screen
+	- Select the "Cut Release" workflow under "Workflows" on the left
+	- Click on the "Run workflow" drop down button to the right
+	- Fill in the required fields
+		- release_tag
+		- key_ring
+		- key_name
+	- Click on "Run workflow"
 
-```
-git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
-```
+3. Publish Release
+	- Find the draft release on the "Releases" page; [link](https://github.com/sigstore/fulcio/releases)
+		- Click on "tags" link on the Code tab.
+	 	- Click on "Releases" toggle.
+	- Click on the edit icon for the draft release
+	- Update release notes
+	- Click "Publish release"  
+
+## OIDC for Github Actions
+
+One time setup in ./hack/github-oidc-setup.sh. This is to provide GitHub actions access to kick off gcloud builds.
+
+# Cutting a Fulcio Release [manual]
+
+1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
+  - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
+
+	You can get a list of pull requests since the last release by substituting in the date of the last release and running:
+	
+	```
+	git log --pretty="* %s" --after="YYYY-MM-DD"
+	```
+	
+	and a list of authors by running:
+	
+	```
+	git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
+	```
 
 2. Tag the repository
 
-```shell
-$ export RELEASE_TAG=<release version, eg "v1.1.0">
-$ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
-$ git push origin ${RELEASE_TAG}
-```
+	```shell
+	$ export RELEASE_TAG=<release version, eg "v1.1.0">
+	$ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
+	$ git push origin ${RELEASE_TAG}
+	```
 
 3. Submit the cloudbuild Job using the following command:
 
-```shell
-$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
-   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME> \
-   --project <GCP_PROJECT>
-```
-
-Where:
-
-- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
-- `GCP_PROJECT` is the GCP project where we will run the job.
-- `_GIT_TAG` is the release version we are publishing, this will also create the GitHub Tag.
-- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
-- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
-- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
-- `_KEY_RING` key ring name of your cosign key.
-- `_KEY_NAME` key name of your  cosign key.
-- `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
-- `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
+	```shell
+	$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
+	   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME> \
+	   --project <GCP_PROJECT>
+	```
+	
+	Where:
+	
+	- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
+	- `GCP_PROJECT` is the GCP project where we will run the job.
+	- `_GIT_TAG` is the release version we are publishing, this will also create the GitHub Tag.
+	- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
+	- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
+	- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
+	- `_KEY_RING` key ring name of your cosign key.
+	- `_KEY_NAME` key name of your  cosign key.
+	- `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
+	- `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
 
 4. When the job finish, whithout issues, you should be able to see in GitHub a draft release.
 You now can review the release, make any changes if needed and then publish to make it an official release.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Create a Github Actions Workflow that will mostly automate the cutting of a release
- draft a release with specified tag [this uses the gh cli]
- kick off cloud build to create artifacts [this uses gcloud cli]; this will also require the creation of a new service account to leverage the oidc login flow, the commands/script to create the service account is included in the PR.

only inputs needed are 
- release tag
- cosign key ring name
- cosign key name

The last two parameter can be hardcoded or if it is sensitive, stored as a secret and referenced that way. Let me know if this is desirable and I can update the workflow.

To avoid just anyone starting the workflow to create a release, it is hardcoded to allow one of
"bobcallaway","cpanato","dlorenc","lukehinds" to start it.
Anyone else that starts it will result in an immediate failure.

if this approach makes sense, i plan to check in a reusable workflow into sigstore/sigstore and have fulcio|rekor|cosign all have release workflows using it.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

https://github.com/sigstore/public-good-instance/issues/50

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
