### PR TITLE
Extract development documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,6 @@ TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
 
 We **WILL** change this and add intermediaries in the future.
 
-## Build for development
-
-After cloning the repository:
-
-```
-$ make
-```
-
-There are other targets available in the [`Makefile`](Makefile), check it out.
-
 ## API
 
 The API is defined [here](./pkg/api/client.go).

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,11 @@
+# Fulcio Developer documentation
+
+## Build for development
+ 
+After cloning the repository:
+ 
+```
+$ make
+```
+ 
+There are other targets available in the [`Makefile`](Makefile), check it out.


### PR DESCRIPTION
Part of https://github.com/sigstore/fulcio/issues/372

This PR extract the part related to building fulcio for development from README to it's own file in docs/ folder.

/cc @nsmith5
