### PR TITLE
Add unit tests for oidc-EmailFromIDToken method

### DIFF
--- a/pkg/oauthflow/oidc_test.go
+++ b/pkg/oauthflow/oidc_test.go
@@ -1,0 +1,84 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package oauthflow
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/magiconair/properties/assert"
+)
+
+// reflect hack because "claims" field is unexported by oidc IDToken
+// https://github.com/coreos/go-oidc/pull/329
+func updateIDToken(idToken *oidc.IDToken, fieldName string, data []byte) {
+	val := reflect.Indirect(reflect.ValueOf(idToken))
+	member := val.FieldByName(fieldName)
+	pointer := unsafe.Pointer(member.UnsafeAddr())
+	realPointer := (*[]byte)(pointer)
+	*realPointer = data
+}
+
+func TestTokenWithClaims(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputClaims      []byte
+		expectedEmail    string
+		expectedVerified bool
+		expectedErr      error
+	}{{
+		name:             "token with nil claims",
+		inputClaims:      nil,
+		expectedEmail:    "",
+		expectedVerified: false,
+		expectedErr:      errors.New("oidc: claims not set"),
+	}, {
+		name:             "token with empty/no claims",
+		inputClaims:      []byte(`{}`),
+		expectedEmail:    "",
+		expectedVerified: false,
+		expectedErr:      nil,
+	}, {
+		name:             "token with non-verified claims set",
+		inputClaims:      []byte(`{"email":"John.Doe@email.com"}`),
+		expectedEmail:    "John.Doe@email.com",
+		expectedVerified: false,
+		expectedErr:      nil,
+	}, {
+		name:             "token with claims set",
+		inputClaims:      []byte(`{"email":"John.Doe@email.com", "email_verified":true}`),
+		expectedEmail:    "John.Doe@email.com",
+		expectedVerified: true,
+		expectedErr:      nil,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idToken := &oidc.IDToken{}
+			updateIDToken(idToken, "claims", tt.inputClaims)
+			actualEmail, actualVerified, actualErr := EmailFromIDToken(idToken)
+			assert.Equal(t, actualEmail, tt.expectedEmail)
+			assert.Equal(t, actualVerified, tt.expectedVerified)
+			if actualErr != nil {
+				assert.Equal(t, actualErr.Error(), tt.expectedErr.Error())
+			} else {
+				assert.Equal(t, actualErr, tt.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Elizabeth Thomas <email2eliza@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Adding unit tests for EmailFromIDToken method in oauthflow.oidc

#### Ticket Link
Fixes https://github.com/sigstore/fulcio/issues/405

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
