### PR TITLE
Add missing testing dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/magiconair/properties v1.8.5
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1


### PR DESCRIPTION
From https://sigstore.slack.com/archives/C02K0T1LNPQ/p1645575739690499: 

> `go test -v ./...` fails on main for me, but I can't tell why this wasn't caught in CI 🤔 
> ```
> $ go test -v ./...
> go: github.com/sigstore/fulcio/pkg/oauthflow: package github.com/magiconair/properties/assert imported from implicitly required module; to add missing requirements, run:
>	go get github.com/magiconair/properties/assert@v1.8.5
>```
> `go mod tidy` indeed generates a diff adding this dependency so I'll open a PR to add this, but I'm curious about why CI isn't having a bad time....

#### Release Notes

```release-note
NONE
```
