### PR TITLE
Upload code coverage report to CodeCov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Test
-        run: go test -v ./...
+        run: go test -v -covermode=atomic -coverprofile=coverage.out ./...
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
+        with:
+          files: coverage.out
       - name: Ensure no files were modified as a result of the build
         run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff --exit-code


### PR DESCRIPTION
#### Summary

Uploading code coverage reports helps nudge contributors to add tests as the coverage diff is posted to their PR.

#### Ticket Link

Relates to ##368. Reporting helps us get a sense of poorly tested code areas.

#### Release Note

```release-note
* NONE
```
