### PR TITLE
Mirror signed release images from GCR to GHCR as part of release with Cloud Build.

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Start cloudbuild job
         working-directory: ./src/github.com/sigstore/fulcio
-        run: gcloud builds submit --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }} --project=${{ env.PROJECT_ID }}
+        run: gcloud builds submit --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }},_GITHUB_USER=${{ github.actor }} --project=${{ env.PROJECT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ LDFLAGS=-X $(FULCIO_PKG).gitVersion=$(GIT_VERSION) -X $(FULCIO_PKG).gitCommit=$(
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 
+GHCR_PREFIX ?= ghcr.io/sigstore
+
 lint: ## Runs golangci-lint
 	$(GOBIN)/golangci-lint run -v ./...
 

--- a/release/README.md
+++ b/release/README.md
@@ -70,7 +70,7 @@ One time setup in ./hack/github-oidc-setup.sh. This is to provide GitHub actions
 
 	```shell
 	$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
-	   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME> \
+	   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME>,_GITHUB_USER=<GITHUB_USER> \
 	   --project <GCP_PROJECT>
 	```
 	
@@ -86,6 +86,7 @@ One time setup in ./hack/github-oidc-setup.sh. This is to provide GitHub actions
 	- `_KEY_NAME` key name of your  cosign key.
 	- `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
 	- `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
+	- `_GITHUB_USER` GitHub user to authenticate for pushing to GHCR.
 
 4. When the job finish, whithout issues, you should be able to see in GitHub a draft release.
 You now can review the release, make any changes if needed and then publish to make it an official release.

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -86,6 +86,30 @@ steps:
       && make sign-container-release \
       && make sign-keyless-release
 
+- name: gcr.io/cloud-builders/docker
+  entrypoint: 'bash'
+  dir: "go/src/sigstore/fulcio"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - KEY_LOCATION=${_KEY_LOCATION}
+  - KEY_RING=${_KEY_RING}
+  - KEY_NAME=${_KEY_NAME}
+  - KEY_VERSION=${_KEY_VERSION}
+  - GIT_TAG=${_GIT_TAG}
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
+  - COSIGN_EXPERIMENTAL=true
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
+  - GITHUB_USER=${_GITHUB_USER}
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
+      && make copy-signed-release-to-ghcr
+
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_NUMBER}/secrets/GITHUB_TOKEN/versions/latest
@@ -116,3 +140,4 @@ substitutions:
   _KEY_NAME: 'honk-crypto'
   _KEY_VERSION: '1'
   _KEY_LOCATION: 'global'
+  _GITHUB_USER: 'placeholder'

--- a/release/release.mk
+++ b/release/release.mk
@@ -83,3 +83,10 @@ sign-container-release: release-images
 .PHONY: sign-keyless-release
 sign-keyless-release:
 	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/fulcio:$(GIT_VERSION)
+
+####################
+# copy image to GHCR
+####################
+
+.PHONY: copy-signed-release-to-ghcr
+	cosign copy ${KO_PREFIX}/fulcio:$(GIT_VERSION) ${GHCR_PREFIX}/fulcio:$(GIT_VERSION)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Copy signed released image from GCR to GHCR using cosign cli copy command.
This will ensure the signature will be the same between the two registry.

@cpanato I had to plumb a new GITHUB_USER env var to allow docker auth to copy image from GCR to GHCR. Not sure if there is a better way or not. Please take a look.

 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #421 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Signed release images will now be available in GitHub Container Registry
```
