### PR TITLE
release: fix sed to update the manifests

### DIFF
--- a/release/release.mk
+++ b/release/release.mk
@@ -67,7 +67,7 @@ push-manifest:
 
 .PHONY: update-yaml
 update-yaml:
-	sed -i -e 's;$(KO_PREFIX)/fulcio:.*;$(KO_PREFIX)/fulcio:$(GIT_HASH)/g' $(FULCIO_YAML)
+	sed -i -e 's/$(KO_PREFIX)\/fulcio@.*/$(KO_PREFIX)\/fulcio:$(GIT_VERSION)/g' $(FULCIO_YAML)
 
 .PHONY: release-images
 release-images: ko-release push-manifest update-yaml


### PR DESCRIPTION
#### Summary
- while doing some tests notice the sed is kind of broken and also update the var to use the git tag, which I guess was the initial idea

update the sed to make it work

the error
```
Step #3: sed -i -e 's;gcr.io/projectsigstore/fulcio:.*;gcr.io/projectsigstore/fulcio:2f2561a0c752aa4c4cafe14dcdb95b4911b01ff8/g' fulcio-v0.2.0.yaml
Step #3: sed: -e expression #1, char 107: unterminated `s' command
```

after the change and using my docker registry as a name

```
....
        - name: fulcio-server
          image: ctadeu/fulcio:v0.2.0-1-g2bc6c5a-dirty
          ports:
....
```


#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
