### PR TITLE
fix sed and update job

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Start cloudbuild job
         working-directory: ./src/github.com/sigstore/fulcio
-        run: gcloud builds submit --no-source --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }},_GITHUB_USER=${{ github.actor }} --project=${{ env.PROJECT_ID }}
+        run: gcloud builds submit --no-source --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }},_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ env:
 before:
   hooks:
     - go mod tidy
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
 # if running a release we will generate the images in this step
 # if running in the CI the CI env va is set by github action runner and we dont run the ko steps
 # this is needed because we are generating files that goreleaser was not aware to push to GH project release

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -55,38 +55,16 @@ steps:
   - GIT_TAG=${_GIT_TAG}
   - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   - COSIGN_EXPERIMENTAL=true
-  secretEnv:
-  - GITHUB_TOKEN
-  args:
-    - '-c'
-    - |
-      make release
-
-- name: ghcr.io/gythialy/golang-cross:v1.17.8-0@sha256:b5b14c6a61099af5a69864f242766a0dca978d2aea97e311d051ee4f4b7d19ba
-  entrypoint: 'bash'
-  dir: "go/src/sigstore/fulcio"
-  env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
-  - PROJECT_ID=${PROJECT_ID}
-  - KEY_LOCATION=${_KEY_LOCATION}
-  - KEY_RING=${_KEY_RING}
-  - KEY_NAME=${_KEY_NAME}
-  - KEY_VERSION=${_KEY_VERSION}
-  - GIT_TAG=${_GIT_TAG}
   - KO_PREFIX=gcr.io/${PROJECT_ID}
-  - COSIGN_EXPERIMENTAL=true
-  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   secretEnv:
   - GITHUB_TOKEN
   args:
     - '-c'
     - |
       gcloud auth configure-docker \
-      && make sign-container-release \
-      && make sign-keyless-release
+      && make release
 
-- name: gcr.io/cloud-builders/docker
+- name: ghcr.io/gythialy/golang-cross:v1.17.8-0@sha256:b5b14c6a61099af5a69864f242766a0dca978d2aea97e311d051ee4f4b7d19ba
   entrypoint: 'bash'
   dir: "go/src/sigstore/fulcio"
   env:

--- a/release/release.mk
+++ b/release/release.mk
@@ -67,7 +67,7 @@ push-manifest:
 
 .PHONY: update-yaml
 update-yaml:
-	sed -i -e 's/$(KO_PREFIX)\/fulcio@.*/$(KO_PREFIX)\/fulcio:$(GIT_VERSION)/g' $(FULCIO_YAML)
+	sed -i -e 's/$(subst /,\/,$(KO_PREFIX))\/fulcio@.*/$(subst /,\/,$(KO_PREFIX))\/fulcio:$(GIT_VERSION)/g' $(FULCIO_YAML)
 
 .PHONY: release-images
 release-images: ko-release push-manifest update-yaml


### PR DESCRIPTION
#### Summary
- the sed was missing to parse the KO_PREFIX env var brackets so that fail as well
```
Step #3: sha256:5f67c995503680f34105fae4d825c057dbed16056ceabc4926de2c3ab82574ef
Step #3: sed -i -e 's/gcr.io/projectsigstore\/fulcio@.*/gcr.io/projectsigstore\/fulcio:v0.2.0/g' fulcio-v0.2.0.yaml
Step #3: sed: -e expression #1, char 38: unknown option to `s'
```

- update the github user to the bot, which is the token key we use in cloudbuild
- remove duplicate step in cloudbuild
- update image to do the image copy to have cosign

rehearsal using this change https://github.com/cpanato/fulcio/releases/tag/v99.99.02

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
