### PR TITLE
Use reusuable release workflow in sigstore/sigstore

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -21,35 +21,14 @@ concurrency: cut-release
 jobs:
   cut-release:
     name: Cut release
-    runs-on: ubuntu-latest
+    uses: sigstore/sigstore/.github/workflows/reusable-release.yml@main
     permissions:
       id-token: write
       contents: read
-    env:
-      GIT_TAG: ${{ github.event.inputs.release_tag }}
-      PROJECT_ID: 'projectsigstore'
-    steps:
-      - name: Check actor access
-        if: ${{ !contains(fromJson('["bobcallaway","cpanato","dlorenc","lukehinds"]'), github.actor) }}
-        run: exit 1
-
-      - name: Checkout out repo
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
-        with:
-          path: ./src/github.com/sigstore/fulcio
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@8d125895b958610ec414ca4dae010257eaa814d3 # v0.6.0
-        with:
-          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-fulcio'
-          service_account: 'github-actions-fulcio@projectsigstore.iam.gserviceaccount.com'
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb # v0.6.0
-        with:
-          project_id: ${{ env.PROJECT_ID }}
-          export_default_credentials: true
-
-      - name: Start cloudbuild job
-        working-directory: ./src/github.com/sigstore/fulcio
-        run: gcloud builds submit --no-source --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.GIT_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=fulcio,_STORAGE_LOCATION=fulcio-releases,_KEY_RING=${{ github.event.inputs.key_ring }},_KEY_NAME=${{ github.event.inputs.key_name }},_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}
+    with:
+      release_tag: ${{ github.event.inputs.release_tag }}
+      key_ring: ${{ github.event.inputs.key_ring }}
+      key_name: ${{ github.event.inputs.key_name }}
+      workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-fulcio'
+      service_account: 'github-actions-fulcio@projectsigstore.iam.gserviceaccount.com'
+      repo: 'fulcio'


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Leverage the reusable Release workflow in sigstore/sigstore repo so releases will be cut in the same manner across Cosign|Rekor|Fulcio.

The reusable workflow is pending review in https://github.com/sigstore/sigstore/pull/325

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

Works toward fixing https://github.com/sigstore/public-good-instance/issues/50

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
