### PR TITLE
Refactor API tests

### DIFF
--- a/pkg/api/ca.go
+++ b/pkg/api/ca.go
@@ -271,6 +271,8 @@ func ExtractSubject(ctx context.Context, tok *oidc.IDToken, publicKey crypto.Pub
 		return challenges.Kubernetes(ctx, tok, publicKey, challenge)
 	case config.IssuerTypeURI:
 		return challenges.URI(ctx, tok, publicKey, challenge)
+	case config.IssuerTypeUsername:
+		return challenges.Username(ctx, tok, publicKey, challenge)
 	default:
 		return nil, fmt.Errorf("unsupported issuer: %s", iss.Type)
 	}

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -85,6 +85,8 @@ func MakeX509(subject *challenges.ChallengeResult) (*x509.Certificate, error) {
 			return nil, ca.ValidationError(err)
 		}
 		cert.URIs = []*url.URL{subjectURI}
+	case challenges.UsernameValue:
+		cert.EmailAddresses = []string{subject.Value}
 	}
 	cert.ExtraExtensions = append(IssuerExtension(subject.Issuer), AdditionalExtensions(subject)...)
 	return cert, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type OIDCIssuer struct {
 	// Optional, if the issuer is in a different claim in the OIDC token
 	IssuerClaim string `json:"IssuerClaim,omitempty"`
 	// The domain that must be present in the subject for 'uri' issuer types
+	// Also used to create an email for 'username' issuer types
 	SubjectDomain string `json:"SubjectDomain,omitempty"`
 }
 
@@ -167,6 +168,7 @@ const (
 	IssuerTypeKubernetes     = "kubernetes"
 	IssuerTypeSpiffe         = "spiffe"
 	IssuerTypeURI            = "uri"
+	IssuerTypeUsername       = "username"
 )
 
 func parseConfig(b []byte) (cfg *FulcioConfig, err error) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

[](https://github.com/haydentherapper)This refactor adds tests for all supported OIDC types, and makes it
simpler to add new tests for new OIDC types.

* Add tests for K8s and GitHub OIDC types.
* Add additional verification for issued certificate values
* Add dedicated test for RootCert success, don't call RootCert in every test.
* Move common expectations to function. This provides a single place to
  check response values.
* Move common set up to dedicated functions.
* Lowercase all error messages, because style.

Once #463 is submitted, I'll rebase.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
