### PR TITLE
fix build date format for version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BIN_DIR := $(abspath $(ROOT_DIR)/bin)
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 GIT_TAG ?= dirty-tag
-DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")


### PR DESCRIPTION
#### Summary
- fix build date format for version command

xref: https://github.com/sigstore/cosign/pull/1644

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
