### PR TITLE
Generate larger, compliant serial numbers

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -24,13 +24,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"math"
-	"math/big"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/sigstore/fulcio/pkg/ca/x509ca"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -106,8 +105,7 @@ func runCreateCACmd(cmd *cobra.Command, args []string) {
 
 	pubKey := privKey.Public()
 
-	// TODO: We could make it so this could be passed in by the user
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	serialNumber, err := x509ca.GenerateSerialNumber()
 	if err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/go-cmp v0.5.7
-	github.com/google/uuid v1.3.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/magiconair/properties v1.8.6
 	github.com/miekg/pkcs11 v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -543,7 +543,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/ca/ephemeralca/ephemeral.go
+++ b/pkg/ca/ephemeralca/ephemeral.go
@@ -19,8 +19,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math"
-	"math/big"
 	"time"
 
 	"github.com/sigstore/fulcio/pkg/ca/x509ca"
@@ -42,8 +40,7 @@ func NewEphemeralCA() (*EphemeralCA, error) {
 
 	e.PrivKey = signer
 
-	// TODO: We could make it so this could be passed in by the user
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	serialNumber, err := x509ca.GenerateSerialNumber()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ca/x509ca/common_test.go
+++ b/pkg/ca/x509ca/common_test.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509ca
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestGenerateSerialNumber(t *testing.T) {
+	serialNumber, err := GenerateSerialNumber()
+	if err != nil {
+		t.Fatalf("unexpected error generating serial number: %v", err)
+	}
+	if serialNumber.Cmp(big.NewInt(0)) == -1 {
+		t.Fatalf("serial number is negative: %v", serialNumber)
+	}
+	if serialNumber.Cmp(big.NewInt(0)) == 0 {
+		t.Fatalf("serial number is 0: %v", serialNumber)
+	}
+	maxSerial := (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil)
+	// Serial number must be less than max serial number.
+	if serialNumber.Cmp(maxSerial) >= 0 {
+		t.Fatalf("serial number is too large: %v", serialNumber)
+	}
+}


### PR DESCRIPTION
UUIDs generate 16 byte serial numbers. Serial numbers can be no larger
than 20 bytes. They also must be positive, giving us 159 bits to
generate a serial number.

This does not affect prod currently, since CA Service generates its own serial numbers. This will affect prod once we switch to using an intermediate CA.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Generate 20 byte positive serial numbers for certificates
```
