### PR TITLE
Use provided HTTP client instead when fetching root cert

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -135,7 +135,11 @@ func (c *client) RootCert() (*RootResponse, error) {
 	endpoint := *c.baseURL
 	endpoint.Path = path.Join(endpoint.Path, rootCertPath)
 
-	resp, err := http.Get(endpoint.String())
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhall@redhat.com>

Fixes #501 

```release-note
Client request to fetch root cert honors provided timeout and useragent
```

@vaikas 