### PR TITLE
Add note about the status of the legacy HTTP API.

### DIFF
--- a/fulcio.proto
+++ b/fulcio.proto
@@ -24,6 +24,12 @@ option java_package = "dev.sigstore.fulcio.v2";
 option java_multiple_files = true;
 option java_outer_classname = "FulcioProto";
 
+// For Fulcio developers: All features should be designed with HTTP support in
+// mind, since some clients may access this API over HTTP rather than gRPC.
+//
+// If there's a feature that you think would negatively impact the HTTP API,
+// open an issue to discuss.
+
 service CA {
     /**
      * Returns an X.509 certificate created by the Fulcio certificate authority for the given request parameters

--- a/fulcio_legacy.proto
+++ b/fulcio_legacy.proto
@@ -30,7 +30,7 @@ option java_outer_classname = "FulcioProto";
 
 /*
  * This implements the pre-GA HTTP-based Fulcio API.
- * This interface is deprecated and will not receive backports of most new features - clients should prefer the GA GRPC interface!
+ * This interface is deprecated and will only receive backports of security-related features - clients should prefer the GA GRPC interface!
  */
 service CA {
     /*

--- a/fulcio_legacy.proto
+++ b/fulcio_legacy.proto
@@ -26,9 +26,11 @@ option java_package = "dev.sigstore.fulcio.v1beta";
 option java_multiple_files = true;
 option java_outer_classname = "FulcioProto";
 
+
+
 /*
  * This implements the pre-GA HTTP-based Fulcio API.
- * This interface is deprecated - clients should prefer the GA GRPC interface!
+ * This interface is deprecated and will not receive backports of most new features - clients should prefer the GA GRPC interface!
  */
 service CA {
     /*


### PR DESCRIPTION

#### Summary

Small doc clarification about the legacy HTTP API.

#### Ticket Link
No ticket, but this came up in the 2022-04-19 community meeting.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
