### PR TITLE
Fix key usage for issued certificates

### DIFF
--- a/pkg/api/grpc_server_test.go
+++ b/pkg/api/grpc_server_test.go
@@ -1225,8 +1225,8 @@ func verifyResponse(resp *protobuf.SigningCertificate, eca *ephemeralca.Ephemera
 	if len(leafCert.SubjectKeyId) != 20 {
 		t.Fatalf("expected certificate subject key ID to be of length 20 bytes, got %d", len(leafCert.SubjectKeyId))
 	}
-	if leafCert.KeyUsage != x509.KeyUsageCertSign {
-		t.Fatalf("unexpected key usage, expected %v, got %v", x509.KeyUsageCertSign, leafCert.KeyUsage)
+	if leafCert.KeyUsage != x509.KeyUsageDigitalSignature {
+		t.Fatalf("unexpected key usage, expected %v, got %v", x509.KeyUsageDigitalSignature, leafCert.KeyUsage)
 	}
 	if len(leafCert.ExtKeyUsage) != 1 {
 		t.Fatalf("unexpected length of extended key usage, expected 1, got %d", len(leafCert.ExtKeyUsage))

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -55,7 +55,7 @@ func MakeX509(subject *challenges.ChallengeResult) (*x509.Certificate, error) {
 		NotAfter:     time.Now().Add(time.Minute * 10),
 		SubjectKeyId: skid,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
-		KeyUsage:     x509.KeyUsageCertSign,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 
 	switch subject.TypeVal {


### PR DESCRIPTION
The key usage should be Digital Signature, not Key Cert Sign. The latter
requires that isCA also be asserted. The certificate's key is only used
to verify signatures, not certificates.

Note that this does not affect the GCP CA.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #550

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed key usage for issued certificates not from GCP CA Service
```
