### PR TITLE
Remove unused `Subject` field from `CodeSigningCertificate`

### DIFF
--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -186,5 +186,5 @@ func (c *CertAuthorityService) CreateCertificate(ctx context.Context, subj *chal
 		return nil, err
 	}
 
-	return ca.CreateCSCFromPEM(subj, resp.PemCertificate, resp.PemCertificateChain)
+	return ca.CreateCSCFromPEM(resp.PemCertificate, resp.PemCertificateChain)
 }

--- a/pkg/ca/intermediateca/intermediateca.go
+++ b/pkg/ca/intermediateca/intermediateca.go
@@ -69,13 +69,12 @@ func (ica *IntermediateCA) CreatePrecertificate(ctx context.Context, challenge *
 		return nil, err
 	}
 
-	csc, err := ca.CreateCSCFromDER(challenge, finalCertBytes, certChain)
+	csc, err := ca.CreateCSCFromDER(finalCertBytes, certChain)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ca.CodeSigningPreCertificate{
-		Subject:    csc.Subject,
 		PreCert:    csc.FinalCertificate,
 		CertChain:  csc.FinalChain,
 		PrivateKey: privateKey,
@@ -128,7 +127,7 @@ func (ica *IntermediateCA) IssueFinalCertificate(ctx context.Context, precert *c
 		return nil, err
 	}
 
-	return ca.CreateCSCFromDER(precert.Subject, finalCertBytes, precert.CertChain)
+	return ca.CreateCSCFromDER(finalCertBytes, precert.CertChain)
 }
 
 func (ica *IntermediateCA) CreateCertificate(ctx context.Context, challenge *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
@@ -144,7 +143,7 @@ func (ica *IntermediateCA) CreateCertificate(ctx context.Context, challenge *cha
 		return nil, err
 	}
 
-	return ca.CreateCSCFromDER(challenge, finalCertBytes, certChain)
+	return ca.CreateCSCFromDER(finalCertBytes, certChain)
 }
 
 func (ica *IntermediateCA) Root(ctx context.Context) ([]byte, error) {

--- a/pkg/ca/intermediateca/intermediateca_test.go
+++ b/pkg/ca/intermediateca/intermediateca_test.go
@@ -161,12 +161,6 @@ func TestCreatePrecertificateAndIssueFinalCertificate(t *testing.T) {
 	subCert, subKey, _ := test.GenerateSubordinateCA(rootCert, rootKey)
 
 	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	challenge := &challenges.ChallengeResult{
-		Issuer:    "iss",
-		TypeVal:   challenges.EmailValue,
-		Value:     "foo@example.com",
-		PublicKey: priv.Public(),
-	}
 	certChain := []*x509.Certificate{subCert, rootCert}
 
 	ica := IntermediateCA{Certs: certChain, Signer: subKey}
@@ -179,9 +173,6 @@ func TestCreatePrecertificateAndIssueFinalCertificate(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("error generating precertificate: %v", err)
-	}
-	if !reflect.DeepEqual(*precsc.Subject, *challenge) {
-		t.Fatalf("challenges are not equal, got %v, expected %v", *precsc.Subject, *challenge)
 	}
 	if !subKey.Equal(precsc.PrivateKey) {
 		t.Fatal("subordinate private keys are not equal")

--- a/pkg/ca/x509ca/common.go
+++ b/pkg/ca/x509ca/common.go
@@ -140,7 +140,7 @@ func (x *X509CA) CreateCertificate(_ context.Context, subject *challenges.Challe
 		return nil, err
 	}
 
-	return ca.CreateCSCFromDER(subject, finalCertBytes, []*x509.Certificate{x.RootCA})
+	return ca.CreateCSCFromDER(finalCertBytes, []*x509.Certificate{x.RootCA})
 }
 
 // GenerateSerialNumber creates a compliant serial number as per RFC 5280 4.1.2.2.


### PR DESCRIPTION
#### Summary

Removes the `Subject` field from `CodeSigningCertificate` and `CodeSigningPreCertificate` as the field is unused in the rest
of the code base. This change helps to remove the usage of `challenges.ChallengeResult` in general as we move to the newer
identity issuer abstraction.

_Bonus_: Check out that git commit signature! Signed by Fulcio :D

#### Release Note

```release-note
NONE
```
