### PR TITLE
Small `ca` refactor

### DIFF
--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ca
+
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/pkg/challenges"
+)
+
+// CertificateAuthority implements certificate creation with a detached SCT and
+// fetching the CA trust bundle.
+type CertificateAuthority interface {
+	CreateCertificate(ctx context.Context, challenge *challenges.ChallengeResult) (*CodeSigningCertificate, error)
+	Root(ctx context.Context) ([]byte, error)
+}

--- a/pkg/ca/csc.go
+++ b/pkg/ca/csc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Sigstore Authors.
+// Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,18 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package ca
 
 import (
-	"context"
-	"crypto"
 	"crypto/x509"
 	"strings"
 
-	ct "github.com/google/certificate-transparency-go"
-	"github.com/sigstore/fulcio/pkg/challenges"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
@@ -31,17 +26,6 @@ type CodeSigningCertificate struct {
 	FinalChain       []*x509.Certificate
 	finalPEM         string
 	finalChainPEM    []string
-}
-
-// CodeSigningPreCertificate holds a precertificate and chain.
-type CodeSigningPreCertificate struct {
-	// PreCert contains the precertificate. Not a valid certificate due to a critical poison extension.
-	PreCert *x509.Certificate
-	// CertChain contains the certificate chain to verify the precertificate.
-	CertChain []*x509.Certificate
-	// PrivateKey contains the signing key used to sign the precertificate. Will be used to sign the certificate.
-	// Included in case the signing key is rotated in between precertificate generation and final issuance.
-	PrivateKey crypto.Signer
 }
 
 func CreateCSCFromPEM(cert string, chain []string) (*CodeSigningCertificate, error) {
@@ -112,19 +96,3 @@ func (c *CodeSigningCertificate) ChainPEM() ([]string, error) {
 	}
 	return c.finalChainPEM, nil
 }
-
-// CertificateAuthority implements certificate creation with a detached SCT and fetching the CA trust bundle.
-type CertificateAuthority interface {
-	CreateCertificate(ctx context.Context, challenge *challenges.ChallengeResult) (*CodeSigningCertificate, error)
-	Root(ctx context.Context) ([]byte, error)
-}
-
-// EmbeddedSCTCA implements precertificate and certificate issuance. Certificates will contain an embedded SCT.
-type EmbeddedSCTCA interface {
-	CreatePrecertificate(ctx context.Context, challenge *challenges.ChallengeResult) (*CodeSigningPreCertificate, error)
-	IssueFinalCertificate(ctx context.Context, precert *CodeSigningPreCertificate, sct *ct.SignedCertificateTimestamp) (*CodeSigningCertificate, error)
-}
-
-// ValidationError indicates that there is an issue with the content in the HTTP Request that
-// should result in an HTTP 400 Bad Request error being returned to the client
-type ValidationError error

--- a/pkg/ca/csc_test.go
+++ b/pkg/ca/csc_test.go
@@ -1,0 +1,220 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ca
+
+import (
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+)
+
+func TestCreateCSCFromDER(t *testing.T) {
+	tests := map[string]struct {
+		CertificatePEM string
+		ChainPEM       []string
+		WantErr        bool
+	}{
+		"Good certificate chain should parse without error": {
+			CertificatePEM: `-----BEGIN CERTIFICATE-----
+MIICFDCCAZmgAwIBAgIUAPsd9CUVr9TNG8nRzYHJrC/ZjtowCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA1MTExNjI4MjRaFw0yMjA1MTExNjM4MjNaMAAwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATGZIJr9odbCYVecVDp9LB1Ye9ehw7tCvPphaKQY832ftnRYFluAb6G
+TtsmHqms4TXsTbvKHFJ9IxtvS6m2uJ6ao4HGMIHDMA4GA1UdDwEB/wQEAwIHgDAT
+BgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTAROUd
+EzzWfUH12GTQKrm84cGngTAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF
++jAjBgNVHREBAf8EGTAXgRVuYXRoYW5AY2hhaW5ndWFyZC5kZXYwKQYKKwYBBAGD
+vzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMAoGCCqGSM49BAMDA2kA
+MGYCMQDUnEwydrGWXaMdhE4JXvNAxAPI6iZzDFZAmqTsOyeSV1LWeFQIgrOGHQwB
+ObpE85YCMQCNhS9zht0xv7j2FGuLshR3aLMTzY3UFBC3pEcI+yy4hI12MHh4laKT
+yhW8MpHgDWs=
+-----END CERTIFICATE-----`,
+			ChainPEM: []string{
+				`-----BEGIN CERTIFICATE-----
+MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl
+LmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7
+XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex
+X69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j
+YzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY
+wB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ
+KsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM
+WP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9
+TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
+-----END CERTIFICATE-----`,
+			},
+			WantErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var certDer []byte
+			{
+				buf := []byte(test.CertificatePEM)
+				block, _ := pem.Decode(buf)
+				if block == nil {
+					t.Fatal("bad certificate format")
+				}
+				certDer = block.Bytes
+			}
+
+			chainBytes := []byte(strings.Join(test.ChainPEM, ""))
+			chain, err := cryptoutils.UnmarshalCertificatesFromPEM(chainBytes)
+			if err != nil {
+				t.Fatal("bad ca chain format")
+			}
+
+			csc, err := CreateCSCFromDER(certDer, chain)
+			if err != nil {
+				if !test.WantErr {
+					t.Error(err)
+				}
+				return
+			}
+
+			gotCert, err := csc.CertPEM()
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(gotCert, test.CertificatePEM); diff != "" {
+				t.Error(diff)
+			}
+
+			gotChain, err := csc.ChainPEM()
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(gotChain, test.ChainPEM); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+func TestCreateCSCFromPEM(t *testing.T) {
+	tests := map[string]struct {
+		CertificatePEM string
+		ChainPEM       []string
+		WantErr        bool
+	}{
+		"Good certificate chain should parse without error": {
+			CertificatePEM: `-----BEGIN CERTIFICATE-----
+MIICFDCCAZmgAwIBAgIUAPsd9CUVr9TNG8nRzYHJrC/ZjtowCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA1MTExNjI4MjRaFw0yMjA1MTExNjM4MjNaMAAwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATGZIJr9odbCYVecVDp9LB1Ye9ehw7tCvPphaKQY832ftnRYFluAb6G
+TtsmHqms4TXsTbvKHFJ9IxtvS6m2uJ6ao4HGMIHDMA4GA1UdDwEB/wQEAwIHgDAT
+BgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTAROUd
+EzzWfUH12GTQKrm84cGngTAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF
++jAjBgNVHREBAf8EGTAXgRVuYXRoYW5AY2hhaW5ndWFyZC5kZXYwKQYKKwYBBAGD
+vzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMAoGCCqGSM49BAMDA2kA
+MGYCMQDUnEwydrGWXaMdhE4JXvNAxAPI6iZzDFZAmqTsOyeSV1LWeFQIgrOGHQwB
+ObpE85YCMQCNhS9zht0xv7j2FGuLshR3aLMTzY3UFBC3pEcI+yy4hI12MHh4laKT
+yhW8MpHgDWs=
+-----END CERTIFICATE-----`,
+			ChainPEM: []string{
+				`-----BEGIN CERTIFICATE-----
+MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl
+LmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7
+XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex
+X69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j
+YzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY
+wB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ
+KsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM
+WP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9
+TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
+-----END CERTIFICATE-----`,
+			},
+			WantErr: false,
+		},
+		"Bad leaf certificate format should error": {
+			CertificatePEM: `-----BEGIN CERTIFICATE-----
+BOO!
+-----END CERTIFICATE-----`,
+			ChainPEM: []string{
+				`-----BEGIN CERTIFICATE-----
+MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl
+LmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7
+XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex
+X69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j
+YzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY
+wB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ
+KsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM
+WP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9
+TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
+-----END CERTIFICATE-----`,
+			},
+			WantErr: true,
+		},
+		"Bad chain certificate format should error": {
+			CertificatePEM: `-----BEGIN CERTIFICATE-----
+MIICFDCCAZmgAwIBAgIUAPsd9CUVr9TNG8nRzYHJrC/ZjtowCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA1MTExNjI4MjRaFw0yMjA1MTExNjM4MjNaMAAwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATGZIJr9odbCYVecVDp9LB1Ye9ehw7tCvPphaKQY832ftnRYFluAb6G
+TtsmHqms4TXsTbvKHFJ9IxtvS6m2uJ6ao4HGMIHDMA4GA1UdDwEB/wQEAwIHgDAT
+BgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTAROUd
+EzzWfUH12GTQKrm84cGngTAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF
++jAjBgNVHREBAf8EGTAXgRVuYXRoYW5AY2hhaW5ndWFyZC5kZXYwKQYKKwYBBAGD
+vzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMAoGCCqGSM49BAMDA2kA
+MGYCMQDUnEwydrGWXaMdhE4JXvNAxAPI6iZzDFZAmqTsOyeSV1LWeFQIgrOGHQwB
+ObpE85YCMQCNhS9zht0xv7j2FGuLshR3aLMTzY3UFBC3pEcI+yy4hI12MHh4laKT
+yhW8MpHgDWs=
+-----END CERTIFICATE-----`,
+			ChainPEM: []string{
+				`-----BEGIN CERTIFICATE-----
+BOO!
+-----END CERTIFICATE-----`,
+			},
+			WantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			csc, err := CreateCSCFromPEM(test.CertificatePEM, test.ChainPEM)
+			if err != nil {
+				if !test.WantErr {
+					t.Error(err)
+				}
+				return
+			}
+
+			gotCert, err := csc.CertPEM()
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(gotCert, test.CertificatePEM); diff != "" {
+				t.Error(diff)
+			}
+
+			gotChain, err := csc.ChainPEM()
+			if err != nil {
+				t.Error(err)
+			}
+			if diff := cmp.Diff(gotChain, test.ChainPEM); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/ca/cspc.go
+++ b/pkg/ca/cspc.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ca
+
+import (
+	"crypto"
+	"crypto/x509"
+)
+
+// CodeSigningPreCertificate holds a precertificate and chain.
+type CodeSigningPreCertificate struct {
+	// PreCert contains the precertificate. Not a valid certificate due to a critical poison extension.
+	PreCert *x509.Certificate
+	// CertChain contains the certificate chain to verify the precertificate.
+	CertChain []*x509.Certificate
+	// PrivateKey contains the signing key used to sign the precertificate. Will be used to sign the certificate.
+	// Included in case the signing key is rotated in between precertificate generation and final issuance.
+	PrivateKey crypto.Signer
+}

--- a/pkg/ca/embeddedca.go
+++ b/pkg/ca/embeddedca.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ca
+
+import (
+	"context"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/sigstore/fulcio/pkg/challenges"
+)
+
+// EmbeddedSCTCA implements precertificate and certificate issuance. Certificates will contain an embedded SCT.
+type EmbeddedSCTCA interface {
+	CreatePrecertificate(ctx context.Context, challenge *challenges.ChallengeResult) (*CodeSigningPreCertificate, error)
+	IssueFinalCertificate(ctx context.Context, precert *CodeSigningPreCertificate, sct *ct.SignedCertificateTimestamp) (*CodeSigningCertificate, error)
+}

--- a/pkg/ca/error.go
+++ b/pkg/ca/error.go
@@ -1,0 +1,20 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ca
+
+// ValidationError indicates that there is an issue with the content in the HTTP Request that
+// should result in an HTTP 400 Bad Request error being returned to the client
+type ValidationError error


### PR DESCRIPTION
#### Summary

Slit up the the structs / interfaces in `pkg/ca` into seperate files and add tests for serialization / deserialization methods on `CodeSigningCertificate`

#### Release Note

```release-note
NONE
```
