### PR TITLE
googleca: Don't log all identities

### DIFF
--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/ca/x509ca"
 	"github.com/sigstore/fulcio/pkg/challenges"
-	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"google.golang.org/api/iterator"
 	privatecapb "google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
@@ -162,8 +161,6 @@ func (c *CertAuthorityService) Root(ctx context.Context) ([]byte, error) {
 }
 
 func (c *CertAuthorityService) CreateCertificate(ctx context.Context, subj *challenges.ChallengeResult) (*ca.CodeSigningCertificate, error) {
-	logger := log.ContextLogger(ctx)
-
 	cert, err := x509ca.MakeX509(subj)
 	if err != nil {
 		return nil, ca.ValidationError(err)
@@ -178,8 +175,6 @@ func (c *CertAuthorityService) CreateCertificate(ctx context.Context, subj *chal
 	if err != nil {
 		return nil, ca.ValidationError(err)
 	}
-
-	logger.Infof("requesting cert from %s for %v", c.parent, subj.Value)
 
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {


### PR DESCRIPTION
#### Summary

Removes logging of all subjects we issue certificates for
from the Google CA backend

Addresses [a comment](https://github.com/sigstore/fulcio/pull/570#pullrequestreview-971257886) from #570


#### Release Note

```release-note
* Removed logging of identities from google CA backend
```
