### PR TITLE
challenges: remove ParseCSR

### DIFF
--- a/pkg/api/grpc_server.go
+++ b/pkg/api/grpc_server.go
@@ -78,7 +78,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 	// optionally parse CSR
 	var csr *x509.CertificateRequest
 	if len(request.GetCertificateSigningRequest()) > 0 {
-		csr, err = challenges.ParseCSR(request.GetCertificateSigningRequest())
+		csr, err = cryptoutils.ParseCSR(request.GetCertificateSigningRequest())
 		if err != nil {
 			return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, invalidCSR)
 		}

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/url"
@@ -475,26 +474,6 @@ func ExtractSubject(ctx context.Context, tok *oidc.IDToken, publicKey crypto.Pub
 
 	result.Result.PublicKey = publicKey
 	return result.Result, nil
-}
-
-// TODO: Move to sigstore/sigstore
-func ParseCSR(csr []byte) (*x509.CertificateRequest, error) {
-	derBlock, _ := pem.Decode(csr)
-	if derBlock == nil || derBlock.Bytes == nil {
-		return nil, errors.New("no CSR found while decoding")
-	}
-	correctType := false
-	acceptedHeaders := []string{"CERTIFICATE REQUEST", "NEW CERTIFICATE REQUEST"}
-	for _, v := range acceptedHeaders {
-		if derBlock.Type == v {
-			correctType = true
-		}
-	}
-	if !correctType {
-		return nil, fmt.Errorf("DER type %v is not of any type %v for CSR", derBlock.Type, acceptedHeaders)
-	}
-
-	return x509.ParseCertificateRequest(derBlock.Bytes)
 }
 
 // ParsePublicKey parses a PEM or DER encoded public key, or extracts the public

--- a/pkg/challenges/challenges_test.go
+++ b/pkg/challenges/challenges_test.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -359,52 +358,6 @@ func TestCheckSignatureRSA(t *testing.T) {
 	}
 }
 
-func TestParseCSR(t *testing.T) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	failErr(t, err)
-	csrTmpl := &x509.CertificateRequest{Subject: pkix.Name{CommonName: "test"}}
-	derCSR, err := x509.CreateCertificateRequest(rand.Reader, csrTmpl, priv)
-	failErr(t, err)
-
-	// success with type CERTIFICATE REQUEST
-	pemCSR := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE REQUEST",
-		Bytes: derCSR,
-	})
-	parsedCSR, err := ParseCSR(pemCSR)
-	failErr(t, err)
-	if parsedCSR.Subject.CommonName != "test" {
-		t.Fatalf("unexpected CSR common name")
-	}
-
-	// success with type NEW CERTIFICATE REQUEST
-	pemCSR = pem.EncodeToMemory(&pem.Block{
-		Type:  "NEW CERTIFICATE REQUEST",
-		Bytes: derCSR,
-	})
-	parsedCSR, err = ParseCSR(pemCSR)
-	failErr(t, err)
-	if parsedCSR.Subject.CommonName != "test" {
-		t.Fatalf("unexpected CSR common name")
-	}
-
-	// fails with invalid PEM encoded block
-	_, err = ParseCSR([]byte{1, 2, 3})
-	if err == nil || !strings.Contains(err.Error(), "no CSR found while decoding") {
-		t.Fatalf("expected error parsing invalid CSR, got %v", err)
-	}
-
-	// fails with invalid DER type
-	pemCSR = pem.EncodeToMemory(&pem.Block{
-		Type:  "BEGIN CERTIFICATE",
-		Bytes: derCSR,
-	})
-	_, err = ParseCSR(pemCSR)
-	if err == nil || !strings.Contains(err.Error(), "DER type BEGIN CERTIFICATE is not of any type") {
-		t.Fatalf("expected error parsing invalid CSR, got %v", err)
-	}
-}
-
 func TestParsePublicKey(t *testing.T) {
 	// succeeds with CSR
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -416,7 +369,7 @@ func TestParsePublicKey(t *testing.T) {
 		Type:  "CERTIFICATE REQUEST",
 		Bytes: derCSR,
 	})
-	parsedCSR, err := ParseCSR(pemCSR)
+	parsedCSR, err := cryptoutils.ParseCSR(pemCSR)
 	failErr(t, err)
 	pubKey, err := ParsePublicKey("", parsedCSR)
 	failErr(t, err)


### PR DESCRIPTION
#### Summary

Use `cryptoutils.ParseCSR` and remove the implementation in pkg/challenges.

