### PR TITLE
identity: improve the documentation for Principal.Name()

### DIFF
--- a/pkg/identity/principal.go
+++ b/pkg/identity/principal.go
@@ -20,7 +20,8 @@ import (
 )
 
 type Principal interface {
-	// URI, email etc of principal
+	// Name is the email or subject of OIDC ID token. This value must match the
+	// value signed in the proof of private key possession challenge.
 	Name(ctx context.Context) string
 
 	// Embed all SubjectAltName and custom x509 extension information into


### PR DESCRIPTION
#### Summary
 
Clarifies that Name _must_ match the proof of possession.

@haydentherapper let me know if you can thing of a better name for the method. Happy to add that in here. Thought I'd at least improve the docs while I remembered to.
