### PR TITLE
Refactor challenge verification

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -33,7 +33,9 @@ const (
 	insecurePublicKey      = "The public key supplied in the request is insecure"
 	//nolint
 	invalidCredentials = "There was an error processing the credentials for this request"
-	genericCAError     = "error communicating with CA backend"
+	// nolint
+	invalidIdentityToken = "There was an error processing the identity token"
+	genericCAError       = "error communicating with CA backend"
 )
 
 func handleFulcioGRPCError(ctx context.Context, code codes.Code, err error, message string, fields ...interface{}) error {

--- a/pkg/api/grpc_server.go
+++ b/pkg/api/grpc_server.go
@@ -70,9 +70,17 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 		}
 	}
 
-	principal, err := authorize(ctx, token)
+	// Authenticate OIDC ID token by checking signature
+	idtoken, err := authorize(ctx, token)
 	if err != nil {
 		return nil, handleFulcioGRPCError(ctx, codes.Unauthenticated, err, invalidCredentials)
+	}
+	// Parse authenticated ID token into principal
+	// TODO:(nsmith5) replace this and authorize call above with
+	// just identity.IssuerPool.Authenticate()
+	principal, err := challenges.PrincipalFromIDToken(ctx, idtoken)
+	if err != nil {
+		return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, invalidIdentityToken)
 	}
 
 	// optionally parse CSR
@@ -103,10 +111,15 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 		return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, insecurePublicKey)
 	}
 
-	// verify challenge
-	subject, err := challenges.ExtractSubject(ctx, principal, publicKey, csr, proofOfPossession)
-	if err != nil {
-		return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, invalidSignature)
+	// verify the challenge
+	if csr != nil {
+		if err := csr.CheckSignature(); err != nil {
+			return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, invalidSignature)
+		}
+	} else {
+		if err := challenges.CheckSignature(publicKey, proofOfPossession, principal.Name(ctx)); err != nil {
+			return nil, handleFulcioGRPCError(ctx, codes.InvalidArgument, err, invalidSignature)
+		}
 	}
 
 	var csc *certauth.CodeSigningCertificate
@@ -115,7 +128,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 	// For CAs that do not support embedded SCTs or if the CT log is not configured
 	if sctCa, ok := g.ca.(certauth.EmbeddedSCTCA); !ok || g.ct == nil {
 		// currently configured CA doesn't support pre-certificate flow required to embed SCT in final certificate
-		csc, err = g.ca.CreateCertificate(ctx, subject, publicKey)
+		csc, err = g.ca.CreateCertificate(ctx, principal, publicKey)
 		if err != nil {
 			// if the error was due to invalid input in the request, return HTTP 400
 			if _, ok := err.(certauth.ValidationError); ok {
@@ -165,7 +178,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 			result.GetSignedCertificateDetachedSct().SignedCertificateTimestamp = sctBytes
 		}
 	} else {
-		precert, err := sctCa.CreatePrecertificate(ctx, subject, publicKey)
+		precert, err := sctCa.CreatePrecertificate(ctx, principal, publicKey)
 		if err != nil {
 			// if the error was due to invalid input in the request, return HTTP 400
 			if _, ok := err.(certauth.ValidationError); ok {

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -523,15 +523,11 @@ func PrincipalFromIDToken(ctx context.Context, tok *oidc.IDToken) (identity.Prin
 	return principal, nil
 }
 
-// ParsePublicKey parses a PEM or DER encoded public key, or extracts the public
-// key from the provided CSR. Returns an error if decoding fails or if no public
-// key is found.
-func ParsePublicKey(encodedPubKey string, csr *x509.CertificateRequest) (crypto.PublicKey, error) {
-	if csr == nil && len(encodedPubKey) == 0 {
+// ParsePublicKey parses a PEM or DER encoded public key. Returns an error if
+// decoding fails or if no public key is found.
+func ParsePublicKey(encodedPubKey string) (crypto.PublicKey, error) {
+	if len(encodedPubKey) == 0 {
 		return nil, errors.New("public key not provided")
-	}
-	if csr != nil {
-		return csr.PublicKey, nil
 	}
 	// try to unmarshal as PEM
 	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(encodedPubKey))

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -493,7 +493,7 @@ func validateAllowedDomain(subjectHostname, issuerHostname string) error {
 	return fmt.Errorf("hostname top-level and second-level domains do not match: %s, %s", subjectHostname, issuerHostname)
 }
 
-func ExtractSubject(ctx context.Context, tok *oidc.IDToken, publicKey crypto.PublicKey, csr *x509.CertificateRequest, challenge []byte) (identity.Principal, error) {
+func PrincipalFromIDToken(ctx context.Context, tok *oidc.IDToken) (identity.Principal, error) {
 	iss, ok := config.FromContext(ctx).GetIssuer(tok.Issuer)
 	if !ok {
 		return nil, fmt.Errorf("configuration can not be loaded for issuer %v", tok.Issuer)
@@ -518,18 +518,6 @@ func ExtractSubject(ctx context.Context, tok *oidc.IDToken, publicKey crypto.Pub
 	}
 	if err != nil {
 		return nil, err
-	}
-
-	// verify the proof of possession of the private key
-	if csr != nil {
-		err = csr.CheckSignature()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		if err := CheckSignature(publicKey, challenge, principal.Name(ctx)); err != nil {
-			return nil, err
-		}
 	}
 
 	return principal, nil


### PR DESCRIPTION
#### Summary

The challenge verification logic is sort of mixed up with the OIDC token parsing at the moment. This work makes two changes to this logic to make it a little easier to understand (there is one commit per change so you can read one at a time if desired)

- Break up the OIDC parsing logic and proof of possession verification in `ExtractSubject` into two seperate things
- Group all the logic for verifying a CSR together and all the logic for verify a signed subject proof of possession together. Make a really clear branch in logic between these two completely different challenges.