### PR TITLE
Skip tests that require network access with HERMETIC=true

### DIFF
--- a/pkg/config/config_network_test.go
+++ b/pkg/config/config_network_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build !hermetic
+
+package config
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestLoad(t *testing.T) {
+	td := t.TempDir()
+	cfgPath := filepath.Join(td, "config.json")
+	if err := ioutil.WriteFile(cfgPath, []byte(validCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := Load(cfgPath)
+	got, ok := cfg.GetIssuer("https://accounts.google.com")
+	if !ok {
+		t.Error("expected true, got false")
+	}
+	if got.ClientID != "foo" {
+		t.Errorf("expected foo, got %s", got.ClientID)
+	}
+	if got.IssuerURL != "https://accounts.google.com" {
+		t.Errorf("expected https://accounts.google.com, got %s", got.IssuerURL)
+	}
+	if got := len(cfg.OIDCIssuers); got != 1 {
+		t.Errorf("expected 1 issuer, got %d", got)
+	}
+
+	got, ok = cfg.GetIssuer("https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER")
+	if !ok {
+		t.Error("expected true, got false")
+	}
+	if got.ClientID != "bar" {
+		t.Errorf("expected bar, got %s", got.ClientID)
+	}
+	if got.IssuerURL != "https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER" {
+		t.Errorf("expected https://oidc.eks.fantasy-land.amazonaws.com/id/CLUSTERIDENTIFIER, got %s", got.IssuerURL)
+	}
+
+	if _, ok := cfg.GetIssuer("not_an_issuer"); ok {
+		t.Error("no error returned from an unconfigured issuer")
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	td := t.TempDir()
+
+	// Don't put anything here!
+	cfgPath := filepath.Join(td, "config.json")
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(DefaultConfig, cfg, cmpopts.IgnoreUnexported(FulcioConfig{})); diff != "" {
+		t.Errorf("DefaultConfig(): -want +got: %s", diff)
+	}
+
+	ctx := context.Background()
+
+	if got := FromContext(ctx); nil != got {
+		t.Errorf("FromContext(): %#v, wanted nil", got)
+	}
+
+	ctx = With(ctx, cfg)
+	if diff := cmp.Diff(cfg, FromContext(ctx), cmpopts.IgnoreUnexported(FulcioConfig{})); diff != "" {
+		t.Errorf("FromContext(): -want +got: %s", diff)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ package config
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,6 +41,13 @@ var validCfg = `
 	}
 }
 `
+
+// Skip test when HERMETIC=true is set, since config tests require network access
+func skipHermetic(t *testing.T) {
+	if os.Getenv("HERMETIC") != "" {
+		t.Skip("Skipping testing in hermetic test environment")
+	}
+}
 
 func TestMetaURLs(t *testing.T) {
 	tests := []struct {
@@ -94,6 +102,8 @@ func TestMetaURLs(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
+	skipHermetic(t)
+
 	td := t.TempDir()
 	cfgPath := filepath.Join(td, "config.json")
 	if err := ioutil.WriteFile(cfgPath, []byte(validCfg), 0644); err != nil {
@@ -132,6 +142,8 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadDefaults(t *testing.T) {
+	skipHermetic(t)
+
 	td := t.TempDir()
 
 	// Don't put anything here!


### PR DESCRIPTION
The config tests make outbound network calls since Load() calls
prepare() which fetches the OIDC configs. Tests that call Load() will
now be skipped. Tested with `go test -tags=hermetic ./...` without a
network connection.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #480

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
In hermetic environments, tests that require network access can be skipped with -tags=hermetic
```
