### PR TITLE
Correct SPIFFE trust domain checking

### DIFF
--- a/pkg/api/grpc_server_test.go
+++ b/pkg/api/grpc_server_test.go
@@ -293,7 +293,8 @@ func TestAPIWithUriSubject(t *testing.T) {
 			%q: {
 				"IssuerURL": %q,
 				"ClientID": "sigstore",
-				"Type": "spiffe"
+				"Type": "spiffe",
+				"SPIFFETrustDomain": "foo.com"
 			},
 			%q: {
 				"IssuerURL": %q,
@@ -307,7 +308,7 @@ func TestAPIWithUriSubject(t *testing.T) {
 		t.Fatalf("config.Read() = %v", err)
 	}
 
-	spiffeSubject := strings.ReplaceAll(spiffeIssuer+"/foo/bar", "http", "spiffe")
+	spiffeSubject := "spiffe://foo.com/bar"
 	uriSubject := uriIssuer + "/users/1"
 
 	tests := []oidcTestContainer{


### PR DESCRIPTION
#### Summary

SPIFFE issuers must configure a trust domain. We no longer assume that
the the trust domain has some implicit relationship with the OIDC issuer
domain. Tokens with a mismatch in trust domain are rejected.

#### Release Note

```release-note
* SPIFFE issuers must now configure a trust domain and tokens with mismatched trust domains will be rejected
```
