### PR TITLE
Split pkg/server from pkg/api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ issues:
     - errcheck
     - gosec
   # the following section is due to the legacy API being deprecated
-  - path: pkg/api/legacy_server.go
+  - path: pkg/server/legacy_server.go
     linters:
     - staticcheck
     text: SA1019

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"
 endif
 
-FULCIO_PKG=github.com/sigstore/fulcio/pkg/api
-LDFLAGS=-X $(FULCIO_PKG).gitVersion=$(GIT_VERSION) -X $(FULCIO_PKG).gitCommit=$(GIT_HASH) -X $(FULCIO_PKG).gitTreeState=$(GIT_TREESTATE) -X $(FULCIO_PKG).buildDate=$(BUILD_DATE)
+FULCIO_VERSION_PKG=github.com/sigstore/fulcio/pkg/server
+LDFLAGS=-X $(FULCIO_VERSION_PKG).gitVersion=$(GIT_VERSION) -X $(FULCIO_VERSION_PKG).gitCommit=$(GIT_HASH) -X $(FULCIO_VERSION_PKG).gitTreeState=$(GIT_TREESTATE) -X $(FULCIO_VERSION_PKG).buildDate=$(BUILD_DATE)
 
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)

--- a/cmd/app/grpc.go
+++ b/cmd/app/grpc.go
@@ -27,12 +27,12 @@ import (
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sigstore/fulcio/pkg/api"
 	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	gw "github.com/sigstore/fulcio/pkg/generated/protobuf"
 	gw_legacy "github.com/sigstore/fulcio/pkg/generated/protobuf/legacy"
 	"github.com/sigstore/fulcio/pkg/log"
+	"github.com/sigstore/fulcio/pkg/server"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 )
@@ -75,7 +75,7 @@ func createGRPCServer(cfg *config.FulcioConfig, ctClient *ctclient.LogClient, ba
 		)),
 		grpc.MaxRecvMsgSize(int(maxMsgSize)))
 
-	grpcCAServer := api.NewGRPCCAServer(ctClient, baseca)
+	grpcCAServer := server.NewGRPCCAServer(ctClient, baseca)
 	// Register your gRPC service implementations.
 	gw.RegisterCAServer(myServer, grpcCAServer)
 
@@ -86,7 +86,7 @@ func createGRPCServer(cfg *config.FulcioConfig, ctClient *ctclient.LogClient, ba
 func (g *grpcServer) setupPrometheus(reg *prometheus.Registry) {
 	grpcMetrics := grpc_prometheus.DefaultServerMetrics
 	grpcMetrics.EnableHandlingTimeHistogram()
-	reg.MustRegister(grpcMetrics, api.MetricLatency, api.RequestsCount)
+	reg.MustRegister(grpcMetrics, server.MetricLatency, server.RequestsCount)
 	grpc_prometheus.Register(g.Server)
 }
 
@@ -137,7 +137,7 @@ func createLegacyGRPCServer(cfg *config.FulcioConfig, v2Server gw.CAServer) (*gr
 		)),
 		grpc.MaxRecvMsgSize(int(maxMsgSize)))
 
-	legacyGRPCCAServer := api.NewLegacyGRPCCAServer(v2Server)
+	legacyGRPCCAServer := server.NewLegacyGRPCCAServer(v2Server)
 
 	// Register your gRPC service implementations.
 	gw_legacy.RegisterCAServer(myServer, legacyGRPCCAServer)

--- a/cmd/app/version.go
+++ b/cmd/app/version.go
@@ -18,7 +18,7 @@ package app
 import (
 	"fmt"
 
-	"github.com/sigstore/fulcio/pkg/api"
+	"github.com/sigstore/fulcio/pkg/server"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +43,7 @@ func newVersionCmd() *cobra.Command {
 }
 
 func runVersion(opts *versionOptions) error {
-	v := api.VersionInfo()
+	v := server.VersionInfo()
 	res := v.String()
 
 	if opts.json {

--- a/pkg/server/error.go
+++ b/pkg/server/error.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"context"

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"context"

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package server
 
 import (
 	"context"

--- a/pkg/server/legacy_server.go
+++ b/pkg/server/legacy_server.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"context"

--- a/pkg/server/max_bytes.go
+++ b/pkg/server/max_bytes.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import "net/http"
 

--- a/pkg/server/max_bytes_test.go
+++ b/pkg/server/max_bytes_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"io/ioutil"

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package api
+package server
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Signed-off-by: Miloslav Trmač <mitr@redhat.com>

#### Summary
Split pkg/server from pkg/api

#### Ticket Link
N/A

#### Release Note
```release-note
External users of pkg/api that refer to the server code now need to use pkg/server.
```

---

API clients using `pkg/api.NewClient`, like `github.com/sigstore/cosign`, currently end up depending on all the implementation details of the servers, unnecessarily increasing their binary size and supply-chain attack surface.

Instead, move the server code to a new pkg/server (assuming there are no external users of that functionality), and leave pkg/api as a package only providing a client (as it is used in practice, and documented in various places in this repo).

The move includes `pkg/api/version.go`, because it is only useful with a Go build that specifies the various values at build time, which is unlikely to be the case for any third-party importer of that package.

This shaves over 500 kB from a simple user of `pkg/api.NewClient`.