### PR TITLE
Refactor in-memory signing CAs to use a single implementation

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sigstore/fulcio/pkg/ca/fileca"
 	googlecav1 "github.com/sigstore/fulcio/pkg/ca/googleca/v1"
 	"github.com/sigstore/fulcio/pkg/ca/kmsca"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca/pkcs11ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/spf13/cobra"
@@ -177,7 +177,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	case "googleca":
 		baseca, err = googlecav1.NewCertAuthorityService(cmd.Context(), viper.GetString("gcp_private_ca_parent"))
 	case "pkcs11ca":
-		params := x509ca.Params{
+		params := pkcs11ca.Params{
 			ConfigPath: viper.GetString("pkcs11-config-path"),
 			RootID:     viper.GetString("hsm-caroot-id"),
 		}
@@ -185,7 +185,7 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 			path := viper.GetString("aws-hsm-root-ca-path")
 			params.CAPath = &path
 		}
-		baseca, err = x509ca.NewX509CA(params)
+		baseca, err = pkcs11ca.NewPKCS11CA(params)
 	case "fileca":
 		certFile := viper.GetString("fileca-cert")
 		keyFile := viper.GetString("fileca-key")

--- a/pkg/ca/baseca/baseca.go
+++ b/pkg/ca/baseca/baseca.go
@@ -28,7 +28,6 @@ import (
 	cttls "github.com/google/certificate-transparency-go/tls"
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
@@ -46,7 +45,7 @@ type BaseCA struct {
 }
 
 func (bca *BaseCA) CreatePrecertificate(ctx context.Context, principal identity.Principal, publicKey crypto.PublicKey) (*ca.CodeSigningPreCertificate, error) {
-	cert, err := x509ca.MakeX509(ctx, principal, publicKey)
+	cert, err := ca.MakeX509(ctx, principal, publicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +126,7 @@ func (bca *BaseCA) IssueFinalCertificate(ctx context.Context, precert *ca.CodeSi
 }
 
 func (bca *BaseCA) CreateCertificate(ctx context.Context, principal identity.Principal, publicKey crypto.PublicKey) (*ca.CodeSigningCertificate, error) {
-	cert, err := x509ca.MakeX509(ctx, principal, publicKey)
+	cert, err := ca.MakeX509(ctx, principal, publicKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ca/baseca/baseca.go
+++ b/pkg/ca/baseca/baseca.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"errors"
 
 	ct "github.com/google/certificate-transparency-go"
 	cttls "github.com/google/certificate-transparency-go/tls"
@@ -144,60 +143,4 @@ func (bca *BaseCA) CreateCertificate(ctx context.Context, principal identity.Pri
 func (bca *BaseCA) Root(ctx context.Context) ([]byte, error) {
 	certs, _ := bca.GetSignerWithChain()
 	return cryptoutils.MarshalCertificatesToPEM(certs)
-}
-
-func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer) error {
-	if len(certs) == 0 {
-		return errors.New("certificate chain must contain at least one certificate")
-	}
-
-	roots := x509.NewCertPool()
-	roots.AddCert(certs[len(certs)-1])
-
-	intermediates := x509.NewCertPool()
-	if len(certs) > 1 {
-		for _, intermediate := range certs[1 : len(certs)-1] {
-			intermediates.AddCert(intermediate)
-		}
-	}
-
-	opts := x509.VerifyOptions{
-		Roots:         roots,
-		Intermediates: intermediates,
-		KeyUsages: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageCodeSigning,
-		},
-	}
-	if _, err := certs[0].Verify(opts); err != nil {
-		return err
-	}
-
-	if !certs[0].IsCA {
-		return errors.New("certificate is not a CA")
-	}
-
-	// If using an intermediate, verify that code signing extended key
-	// usage is set to satify extended key usage chainging
-	if len(certs) > 1 {
-		var hasExtKeyUsageCodeSigning bool
-		for _, extKeyUsage := range certs[0].ExtKeyUsage {
-			if extKeyUsage == x509.ExtKeyUsageCodeSigning {
-				hasExtKeyUsageCodeSigning = true
-				break
-			}
-		}
-		if !hasExtKeyUsageCodeSigning {
-			return errors.New(`certificate must have extended key usage code signing set to sign code signing certificates`)
-		}
-	}
-
-	if err := cryptoutils.EqualKeys(certs[0].PublicKey, signer.Public()); err != nil {
-		return err
-	}
-
-	if err := cryptoutils.ValidatePubKey(signer.Public()); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/ca/baseca/baseca_test.go
+++ b/pkg/ca/baseca/baseca_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-package intermediateca
+package baseca
 
 import (
 	"context"
@@ -34,7 +34,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func TestIntermediateCARoot(t *testing.T) {
+func TestBaseCARoot(t *testing.T) {
 	signer, _, err := signature.NewDefaultECDSASignerVerifier()
 	if err != nil {
 		t.Fatalf("unexpected error generating signer: %v", err)
@@ -48,11 +48,11 @@ func TestIntermediateCARoot(t *testing.T) {
 		t.Fatalf("unexpected error marshalling cert chain: %v", err)
 	}
 
-	ica := IntermediateCA{
+	bca := BaseCA{
 		SignerWithChain: &ca.SignerCerts{Certs: certChain, Signer: signer},
 	}
 
-	rootBytes, err := ica.Root(context.TODO())
+	rootBytes, err := bca.Root(context.TODO())
 	if err != nil {
 		t.Fatalf("unexpected error reading root: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestIntermediateCARoot(t *testing.T) {
 	}
 }
 
-func TestIntermediateCAGetSignerWithChain(t *testing.T) {
+func TestBaseCAGetSignerWithChain(t *testing.T) {
 	signer, _, err := signature.NewDefaultECDSASignerVerifier()
 	if err != nil {
 		t.Fatalf("unexpected error generating signer: %v", err)
@@ -72,11 +72,11 @@ func TestIntermediateCAGetSignerWithChain(t *testing.T) {
 	subCert, _, _ := test.GenerateSubordinateCA(rootCert, rootKey)
 	certChain := []*x509.Certificate{subCert, rootCert}
 
-	ica := IntermediateCA{
+	bca := BaseCA{
 		SignerWithChain: &ca.SignerCerts{Certs: certChain, Signer: signer},
 	}
 
-	foundCertChain, foundSigner := ica.GetSignerWithChain()
+	foundCertChain, foundSigner := bca.GetSignerWithChain()
 
 	if !reflect.DeepEqual(certChain, foundCertChain) {
 		t.Fatal("expected cert chains to be equivalent")
@@ -87,7 +87,7 @@ func TestIntermediateCAGetSignerWithChain(t *testing.T) {
 	}
 }
 
-func TestIntermediateCAVerifyCertChain(t *testing.T) {
+func TestBaseCAVerifyCertChain(t *testing.T) {
 	rootCert, rootKey, _ := test.GenerateRootCA()
 	subCert, subKey, _ := test.GenerateSubordinateCA(rootCert, rootKey)
 	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
@@ -176,11 +176,11 @@ func TestCreatePrecertificateAndIssueFinalCertificate(t *testing.T) {
 	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	certChain := []*x509.Certificate{subCert, rootCert}
 
-	ica := IntermediateCA{
+	bca := BaseCA{
 		SignerWithChain: &ca.SignerCerts{Certs: certChain, Signer: subKey},
 	}
 
-	precsc, err := ica.CreatePrecertificate(context.TODO(), testPrincipal{}, priv.Public())
+	precsc, err := bca.CreatePrecertificate(context.TODO(), testPrincipal{}, priv.Public())
 
 	if err != nil {
 		t.Fatalf("error generating precertificate: %v", err)
@@ -202,7 +202,7 @@ func TestCreatePrecertificateAndIssueFinalCertificate(t *testing.T) {
 		t.Fatalf("expected unhandled critical ext error, got %v", err)
 	}
 
-	csc, err := ica.IssueFinalCertificate(context.TODO(), precsc, &ct.SignedCertificateTimestamp{SCTVersion: 1})
+	csc, err := bca.IssueFinalCertificate(context.TODO(), precsc, &ct.SignedCertificateTimestamp{SCTVersion: 1})
 	if err != nil {
 		t.Fatalf("error issuing certificate: %v", err)
 	}

--- a/pkg/ca/baseca/baseca_test.go
+++ b/pkg/ca/baseca/baseca_test.go
@@ -28,7 +28,6 @@ import (
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
 	"github.com/sigstore/fulcio/pkg/test"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -163,7 +162,7 @@ func (tp testPrincipal) Name(context.Context) string {
 
 func (tp testPrincipal) Embed(ctx context.Context, cert *x509.Certificate) (err error) {
 	cert.EmailAddresses = []string{"alice@example.com"}
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: "example.com",
 	}.Render()
 	return

--- a/pkg/ca/baseca/baseca_test.go
+++ b/pkg/ca/baseca/baseca_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"reflect"
-	"strings"
 	"testing"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -83,74 +82,6 @@ func TestBaseCAGetSignerWithChain(t *testing.T) {
 
 	if err := cryptoutils.EqualKeys(signer.Public(), foundSigner.Public()); err != nil {
 		t.Fatalf("expected keys to be equivalent, expected %v, got %v, error %v", signer.Public(), foundSigner.Public(), err)
-	}
-}
-
-func TestBaseCAVerifyCertChain(t *testing.T) {
-	rootCert, rootKey, _ := test.GenerateRootCA()
-	subCert, subKey, _ := test.GenerateSubordinateCA(rootCert, rootKey)
-	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
-
-	err := VerifyCertChain([]*x509.Certificate{subCert, rootCert}, subKey)
-	if err != nil {
-		t.Fatalf("unexpected error verifying cert chain: %v", err)
-	}
-
-	// Handles single certifiacte in chain
-	err = VerifyCertChain([]*x509.Certificate{rootCert}, rootKey)
-	if err != nil {
-		t.Fatalf("unexpected error verifying single cert chain: %v", err)
-	}
-
-	// Handles multiple intermediates
-	subCert2, subKey2, _ := test.GenerateSubordinateCA(subCert, subKey)
-	err = VerifyCertChain([]*x509.Certificate{subCert2, subCert, rootCert}, subKey2)
-	if err != nil {
-		t.Fatalf("unexpected error verifying cert chain: %v", err)
-	}
-
-	// Failure: Certificate is not a CA certificate
-	err = VerifyCertChain([]*x509.Certificate{leafCert}, nil)
-	if err == nil || !strings.Contains(err.Error(), "certificate is not a CA") {
-		t.Fatalf("expected error with non-CA cert: %v", err)
-	}
-
-	// Failure: Certificate missing EKU
-	// Note that the wrong EKU will be caught by x509.Verify
-	invalidSubCert, invalidSubKey, _ := test.GenerateSubordinateCAWithoutEKU(rootCert, rootKey)
-	err = VerifyCertChain([]*x509.Certificate{invalidSubCert, rootCert}, invalidSubKey)
-	if err == nil || !strings.Contains(err.Error(), "certificate must have extended key usage code signing") {
-		t.Fatalf("expected error verifying cert chain without EKU: %v", err)
-	}
-
-	// Failure: Invalid chain
-	rootCert2, _, _ := test.GenerateRootCA()
-	err = VerifyCertChain([]*x509.Certificate{subCert, rootCert2}, subKey)
-	if err == nil || !strings.Contains(err.Error(), "certificate signed by unknown authority") {
-		t.Fatalf("expected error verifying cert chain: %v", err)
-	}
-
-	// Failure: Different signer with different key
-	signer, _, err := signature.NewDefaultECDSASignerVerifier()
-	if err != nil {
-		t.Fatalf("expected error generating signer: %v", err)
-	}
-	err = VerifyCertChain([]*x509.Certificate{subCert, rootCert}, signer)
-	if err == nil || !strings.Contains(err.Error(), "public keys are not equal") {
-		t.Fatalf("expected error verifying cert with mismatched public keys: %v", err)
-	}
-
-	// Failure: Weak key
-	weakSubCert, weakSubKey, _ := test.GenerateWeakSubordinateCA(rootCert, rootKey)
-	err = VerifyCertChain([]*x509.Certificate{weakSubCert, rootCert}, weakSubKey)
-	if err == nil || !strings.Contains(err.Error(), "unsupported ec curve") {
-		t.Fatalf("expected error verifying weak cert chain: %v", err)
-	}
-
-	// Failure: Empty chain
-	err = VerifyCertChain([]*x509.Certificate{}, weakSubKey)
-	if err == nil || !strings.Contains(err.Error(), "certificate chain must contain at least one certificate") {
-		t.Fatalf("expected error verifying with empty chain: %v", err)
 	}
 }
 

--- a/pkg/ca/common.go
+++ b/pkg/ca/common.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"time"
 
 	"github.com/sigstore/fulcio/pkg/identity"
@@ -51,4 +52,60 @@ func MakeX509(ctx context.Context, principal identity.Principal, publicKey crypt
 	}
 
 	return cert, nil
+}
+
+func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer) error {
+	if len(certs) == 0 {
+		return errors.New("certificate chain must contain at least one certificate")
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(certs[len(certs)-1])
+
+	intermediates := x509.NewCertPool()
+	if len(certs) > 1 {
+		for _, intermediate := range certs[1 : len(certs)-1] {
+			intermediates.AddCert(intermediate)
+		}
+	}
+
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageCodeSigning,
+		},
+	}
+	if _, err := certs[0].Verify(opts); err != nil {
+		return err
+	}
+
+	if !certs[0].IsCA {
+		return errors.New("certificate is not a CA")
+	}
+
+	// If using an intermediate, verify that code signing extended key
+	// usage is set to satify extended key usage chainging
+	if len(certs) > 1 {
+		var hasExtKeyUsageCodeSigning bool
+		for _, extKeyUsage := range certs[0].ExtKeyUsage {
+			if extKeyUsage == x509.ExtKeyUsageCodeSigning {
+				hasExtKeyUsageCodeSigning = true
+				break
+			}
+		}
+		if !hasExtKeyUsageCodeSigning {
+			return errors.New(`certificate must have extended key usage code signing set to sign code signing certificates`)
+		}
+	}
+
+	if err := cryptoutils.EqualKeys(certs[0].PublicKey, signer.Public()); err != nil {
+		return err
+	}
+
+	if err := cryptoutils.ValidatePubKey(signer.Public()); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/ca/common_test.go
+++ b/pkg/ca/common_test.go
@@ -20,8 +20,12 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/sigstore/fulcio/pkg/test"
+	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 // cannot use ChallengeResult due to import cycle
@@ -63,5 +67,73 @@ func TestMakeX509(t *testing.T) {
 	// test that Embed is called
 	if len(cert.EmailAddresses) != 1 {
 		t.Fatalf("expected email in subject alt name, got %v", cert.EmailAddresses)
+	}
+}
+
+func TestVerifyCertChain(t *testing.T) {
+	rootCert, rootKey, _ := test.GenerateRootCA()
+	subCert, subKey, _ := test.GenerateSubordinateCA(rootCert, rootKey)
+	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
+
+	err := VerifyCertChain([]*x509.Certificate{subCert, rootCert}, subKey)
+	if err != nil {
+		t.Fatalf("unexpected error verifying cert chain: %v", err)
+	}
+
+	// Handles single certifiacte in chain
+	err = VerifyCertChain([]*x509.Certificate{rootCert}, rootKey)
+	if err != nil {
+		t.Fatalf("unexpected error verifying single cert chain: %v", err)
+	}
+
+	// Handles multiple intermediates
+	subCert2, subKey2, _ := test.GenerateSubordinateCA(subCert, subKey)
+	err = VerifyCertChain([]*x509.Certificate{subCert2, subCert, rootCert}, subKey2)
+	if err != nil {
+		t.Fatalf("unexpected error verifying cert chain: %v", err)
+	}
+
+	// Failure: Certificate is not a CA certificate
+	err = VerifyCertChain([]*x509.Certificate{leafCert}, nil)
+	if err == nil || !strings.Contains(err.Error(), "certificate is not a CA") {
+		t.Fatalf("expected error with non-CA cert: %v", err)
+	}
+
+	// Failure: Certificate missing EKU
+	// Note that the wrong EKU will be caught by x509.Verify
+	invalidSubCert, invalidSubKey, _ := test.GenerateSubordinateCAWithoutEKU(rootCert, rootKey)
+	err = VerifyCertChain([]*x509.Certificate{invalidSubCert, rootCert}, invalidSubKey)
+	if err == nil || !strings.Contains(err.Error(), "certificate must have extended key usage code signing") {
+		t.Fatalf("expected error verifying cert chain without EKU: %v", err)
+	}
+
+	// Failure: Invalid chain
+	rootCert2, _, _ := test.GenerateRootCA()
+	err = VerifyCertChain([]*x509.Certificate{subCert, rootCert2}, subKey)
+	if err == nil || !strings.Contains(err.Error(), "certificate signed by unknown authority") {
+		t.Fatalf("expected error verifying cert chain: %v", err)
+	}
+
+	// Failure: Different signer with different key
+	signer, _, err := signature.NewDefaultECDSASignerVerifier()
+	if err != nil {
+		t.Fatalf("expected error generating signer: %v", err)
+	}
+	err = VerifyCertChain([]*x509.Certificate{subCert, rootCert}, signer)
+	if err == nil || !strings.Contains(err.Error(), "public keys are not equal") {
+		t.Fatalf("expected error verifying cert with mismatched public keys: %v", err)
+	}
+
+	// Failure: Weak key
+	weakSubCert, weakSubKey, _ := test.GenerateWeakSubordinateCA(rootCert, rootKey)
+	err = VerifyCertChain([]*x509.Certificate{weakSubCert, rootCert}, weakSubKey)
+	if err == nil || !strings.Contains(err.Error(), "unsupported ec curve") {
+		t.Fatalf("expected error verifying weak cert chain: %v", err)
+	}
+
+	// Failure: Empty chain
+	err = VerifyCertChain([]*x509.Certificate{}, weakSubKey)
+	if err == nil || !strings.Contains(err.Error(), "certificate chain must contain at least one certificate") {
+		t.Fatalf("expected error verifying with empty chain: %v", err)
 	}
 }

--- a/pkg/ca/ephemeralca/ephemeral.go
+++ b/pkg/ca/ephemeralca/ephemeral.go
@@ -21,13 +21,14 @@ import (
 	"crypto/x509/pkix"
 	"time"
 
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 type EphemeralCA struct {
-	x509ca.X509CA
+	baseca.BaseCA
 }
 
 func NewEphemeralCA() (*EphemeralCA, error) {
@@ -38,8 +39,6 @@ func NewEphemeralCA() (*EphemeralCA, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	e.PrivKey = signer
 
 	serialNumber, err := cryptoutils.GenerateSerialNumber()
 	if err != nil {
@@ -67,10 +66,13 @@ func NewEphemeralCA() (*EphemeralCA, error) {
 		return nil, err
 	}
 
-	e.RootCA, err = x509.ParseCertificate(caBytes)
+	rootCert, err := x509.ParseCertificate(caBytes)
 	if err != nil {
 		return nil, err
 	}
+
+	sc := ca.SignerCerts{Signer: signer, Certs: []*x509.Certificate{rootCert}}
+	e.SignerWithChain = &sc
 
 	return e, nil
 }

--- a/pkg/ca/ephemeralca/ephemeral_test.go
+++ b/pkg/ca/ephemeralca/ephemeral_test.go
@@ -27,22 +27,24 @@ func TestNewEphemeralCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error generating ephemeral CA: %v", err)
 	}
-	if ca.RootCA == nil {
+	certs, signer := ca.GetSignerWithChain()
+	if len(certs) != 1 {
 		t.Fatalf("ca not set up")
 	}
-	if ca.RootCA.NotAfter.Sub(ca.RootCA.NotBefore) < time.Hour*24*365*10 {
-		t.Fatalf("expected CA to have 10 year lifetime, got %v", ca.RootCA.NotAfter.Sub(ca.RootCA.NotBefore))
+	rootCert := certs[0]
+	if rootCert.NotAfter.Sub(rootCert.NotBefore) < time.Hour*24*365*10 {
+		t.Fatalf("expected CA to have 10 year lifetime, got %v", rootCert.NotAfter.Sub(rootCert.NotBefore))
 	}
-	if !ca.RootCA.IsCA {
+	if !rootCert.IsCA {
 		t.Fatalf("ca does not have IsCA bit set")
 	}
-	if ca.RootCA.MaxPathLen != 1 {
-		t.Fatalf("expected CA with path length of 1, got %d", ca.RootCA.MaxPathLen)
+	if rootCert.MaxPathLen != 1 {
+		t.Fatalf("expected CA with path length of 1, got %d", rootCert.MaxPathLen)
 	}
-	if ca.RootCA.KeyUsage != x509.KeyUsageCertSign|x509.KeyUsageCRLSign {
+	if rootCert.KeyUsage != x509.KeyUsageCertSign|x509.KeyUsageCRLSign {
 		t.Fatalf("expected cert sign and crl sign key usage")
 	}
-	if err := cryptoutils.EqualKeys(ca.PrivKey.Public(), ca.RootCA.PublicKey); err != nil {
+	if err := cryptoutils.EqualKeys(signer.Public(), rootCert.PublicKey); err != nil {
 		t.Fatalf("expected verification key and certificate key to match")
 	}
 }

--- a/pkg/ca/extensions.go
+++ b/pkg/ca/extensions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package x509ca
+package ca
 
 import (
 	"crypto/x509/pkix"
@@ -61,7 +61,7 @@ func (e Extensions) Render() ([]pkix.Extension, error) {
 			Value: []byte(e.Issuer),
 		})
 	} else {
-		return nil, errors.New("x509ca: extensions must have a non-empty issuer url")
+		return nil, errors.New("extensions must have a non-empty issuer url")
 	}
 	if e.GithubWorkflowTrigger != "" {
 		exts = append(exts, pkix.Extension{

--- a/pkg/ca/extensions_test.go
+++ b/pkg/ca/extensions_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package x509ca
+package ca
 
 import (
 	"bytes"

--- a/pkg/ca/fileca/fileca.go
+++ b/pkg/ca/fileca/fileca.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/intermediateca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 )
 
 type fileCA struct {
-	intermediateca.IntermediateCA
+	baseca.BaseCA
 }
 
 // NewFileCA returns a file backed certificate authority. Expects paths to a

--- a/pkg/ca/fileca/load.go
+++ b/pkg/ca/fileca/load.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/intermediateca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"go.step.sm/crypto/pemutil"
 )
@@ -58,7 +58,7 @@ func loadKeyPair(certPath, keyPath, keyPass string) (*ca.SignerCertsMutex, error
 		}
 	}
 
-	if err := intermediateca.VerifyCertChain(certs, key); err != nil {
+	if err := baseca.VerifyCertChain(certs, key); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ca/fileca/load.go
+++ b/pkg/ca/fileca/load.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/baseca"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"go.step.sm/crypto/pemutil"
 )
@@ -58,7 +57,7 @@ func loadKeyPair(certPath, keyPath, keyPass string) (*ca.SignerCertsMutex, error
 		}
 	}
 
-	if err := baseca.VerifyCertChain(certs, key); err != nil {
+	if err := ca.VerifyCertChain(certs, key); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ca/googleca/v1/googleca.go
+++ b/pkg/ca/googleca/v1/googleca.go
@@ -30,7 +30,6 @@ import (
 
 	privateca "cloud.google.com/go/security/privateca/apiv1"
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"google.golang.org/api/iterator"
@@ -162,7 +161,7 @@ func (c *CertAuthorityService) Root(ctx context.Context) ([]byte, error) {
 }
 
 func (c *CertAuthorityService) CreateCertificate(ctx context.Context, principal identity.Principal, publicKey crypto.PublicKey) (*ca.CodeSigningCertificate, error) {
-	cert, err := x509ca.MakeX509(ctx, principal, publicKey)
+	cert, err := ca.MakeX509(ctx, principal, publicKey)
 	if err != nil {
 		return nil, ca.ValidationError(err)
 	}

--- a/pkg/ca/kmsca/kmsca.go
+++ b/pkg/ca/kmsca/kmsca.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/sigstore/fulcio/pkg/ca"
-	"github.com/sigstore/fulcio/pkg/ca/intermediateca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
 
@@ -35,7 +35,7 @@ import (
 )
 
 type kmsCA struct {
-	intermediateca.IntermediateCA
+	baseca.BaseCA
 }
 
 func NewKMSCA(ctx context.Context, kmsKey, certPath string) (ca.CertificateAuthority, error) {
@@ -63,7 +63,7 @@ func NewKMSCA(ctx context.Context, kmsKey, certPath string) (ca.CertificateAutho
 	if err != nil {
 		return nil, err
 	}
-	if err := intermediateca.VerifyCertChain(sc.Certs, sc.Signer); err != nil {
+	if err := baseca.VerifyCertChain(sc.Certs, sc.Signer); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ca/kmsca/kmsca.go
+++ b/pkg/ca/kmsca/kmsca.go
@@ -63,7 +63,7 @@ func NewKMSCA(ctx context.Context, kmsKey, certPath string) (ca.CertificateAutho
 	if err != nil {
 		return nil, err
 	}
-	if err := baseca.VerifyCertChain(sc.Certs, sc.Signer); err != nil {
+	if err := ca.VerifyCertChain(sc.Certs, sc.Signer); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ca/pkcs11ca/pkcs11ca.go
+++ b/pkg/ca/pkcs11ca/pkcs11ca.go
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-package x509ca
+package pkcs11ca
 
 import (
 	"crypto/x509"
@@ -40,7 +40,7 @@ type PKCS11CA struct {
 	baseca.BaseCA
 }
 
-func NewX509CA(params Params) (*PKCS11CA, error) {
+func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	pkcs11ca := &PKCS11CA{}
 	p11Ctx, err := crypto11.ConfigureFromFile(params.ConfigPath)
 	if err != nil {

--- a/pkg/ca/pkcs11ca/pkcs11canocgo.go
+++ b/pkg/ca/pkcs11ca/pkcs11canocgo.go
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-package x509ca
+package pkcs11ca
 
 import (
 	"errors"
@@ -28,8 +28,8 @@ type Params struct {
 	CAPath     *string
 }
 
-// NewX509CA is a placeholder for erroring with a meaningful message if the
+// NewPKCS11CA is a placeholder for erroring with a meaningful message if the
 // binary has been built with CGO_ENABLED=0 tags.
-func NewX509CA(params Params) (*X509CA, error) {
+func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	return nil, errors.New("binary has been built with no cgo support, PKCS11 not supported")
 }

--- a/pkg/ca/x509ca/x509ca.go
+++ b/pkg/ca/x509ca/x509ca.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ThalesIgnite/crypto11"
 	"github.com/sigstore/fulcio/pkg/ca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 )
 
 type Params struct {
@@ -35,18 +36,24 @@ type Params struct {
 	CAPath     *string
 }
 
-func NewX509CA(params Params) (ca.CertificateAuthority, error) {
-	ca := &X509CA{}
+type PKCS11CA struct {
+	baseca.BaseCA
+}
+
+func NewX509CA(params Params) (*PKCS11CA, error) {
+	pkcs11ca := &PKCS11CA{}
 	p11Ctx, err := crypto11.ConfigureFromFile(params.ConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
+	var cert *x509.Certificate
+
 	rootID := []byte(params.RootID)
 
 	// get the existing root CA from the HSM or from disk
 	if params.CAPath == nil {
-		ca.RootCA, err = p11Ctx.FindCertificate(rootID, nil, nil)
+		cert, err = p11Ctx.FindCertificate(rootID, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -60,21 +67,24 @@ func NewX509CA(params Params) (ca.CertificateAuthority, error) {
 		if block == nil || block.Type != "CERTIFICATE" {
 			return nil, errors.New("failed to decode PEM block containing certificate")
 		}
-		ca.RootCA, err = x509.ParseCertificate(block.Bytes)
+		cert, err = x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// get the private key object from HSM
-	ca.PrivKey, err = p11Ctx.FindKeyPair(nil, []byte("PKCS11CA"))
+	signer, err := p11Ctx.FindKeyPair(nil, []byte("PKCS11CA"))
 	if err != nil {
 		return nil, err
 	}
-	if ca.PrivKey == nil {
+	if signer == nil {
 		return nil, errors.New("cannot find private key")
 	}
 
-	return ca, nil
+	sc := ca.SignerCerts{Signer: signer, Certs: []*x509.Certificate{cert}}
+	pkcs11ca.SignerWithChain = &sc
+
+	return pkcs11ca, nil
 
 }

--- a/pkg/identity/email/principal.go
+++ b/pkg/identity/email/principal.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/oauthflow"
@@ -64,7 +64,7 @@ func (p principal) Embed(ctx context.Context, cert *x509.Certificate) error {
 	cert.EmailAddresses = []string{p.address}
 
 	var err error
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: p.issuer,
 	}.Render()
 	if err != nil {

--- a/pkg/identity/github/principal.go
+++ b/pkg/identity/github/principal.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -111,7 +111,7 @@ func (w workflowPrincipal) Embed(ctx context.Context, cert *x509.Certificate) er
 	cert.URIs = []*url.URL{parsed}
 
 	// Embed additional information into custom extensions
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer:                   w.issuer,
 		GithubWorkflowTrigger:    w.trigger,
 		GithubWorkflowSHA:        w.sha,

--- a/pkg/identity/kubernetes/principal.go
+++ b/pkg/identity/kubernetes/principal.go
@@ -20,7 +20,7 @@ import (
 	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -59,7 +59,7 @@ func (p principal) Embed(ctx context.Context, cert *x509.Certificate) error {
 	}
 	cert.URIs = []*url.URL{parsed}
 
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: p.issuer,
 	}.Render()
 	if err != nil {

--- a/pkg/identity/spiffe/principal.go
+++ b/pkg/identity/spiffe/principal.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -82,7 +82,7 @@ func (p principal) Embed(ctx context.Context, cert *x509.Certificate) error {
 	}
 	cert.URIs = []*url.URL{parsed}
 
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: p.issuer,
 	}.Render()
 	if err != nil {

--- a/pkg/identity/uri/principal.go
+++ b/pkg/identity/uri/principal.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
@@ -73,7 +73,7 @@ func (p principal) Embed(ctx context.Context, cert *x509.Certificate) error {
 	}
 	cert.URIs = []*url.URL{subjectURI}
 
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: p.issuer,
 	}.Render()
 	if err != nil {

--- a/pkg/identity/username/principal.go
+++ b/pkg/identity/username/principal.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/sigstore/fulcio/pkg/ca/x509ca"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
@@ -62,7 +62,7 @@ func (p principal) Embed(ctx context.Context, cert *x509.Certificate) error {
 	cert.EmailAddresses = []string{p.emailAddress}
 
 	var err error
-	cert.ExtraExtensions, err = x509ca.Extensions{
+	cert.ExtraExtensions, err = ca.Extensions{
 		Issuer: p.issuer,
 	}.Render()
 	if err != nil {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -164,8 +164,9 @@ func TestGetTrustBundleSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse the received root cert: %v", err)
 	}
-	if !rootCert.Equal(eca.RootCA) {
-		t.Errorf("root CA does not match, wanted %+v got %+v", eca.RootCA, rootCert)
+	certs, _ := eca.GetSignerWithChain()
+	if !rootCert.Equal(certs[0]) {
+		t.Errorf("root CA does not match, wanted %+v got %+v", certs[0], rootCert)
 	}
 }
 
@@ -1410,8 +1411,9 @@ func verifyResponse(resp *protobuf.SigningCertificate, eca *ephemeralca.Ephemera
 	if err != nil {
 		t.Fatalf("failed to parse the received root cert: %v", err)
 	}
-	if !rootCert.Equal(eca.RootCA) {
-		t.Errorf("root CA does not match, wanted %+v got %+v", eca.RootCA, rootCert)
+	certs, _ := eca.GetSignerWithChain()
+	if !rootCert.Equal(certs[0]) {
+		t.Errorf("root CA does not match, wanted %+v got %+v", certs[0], rootCert)
 	}
 
 	// Expect leaf certificate values


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

There is no difference between the CreateCertificate implementation for x509ca and intermediateca, so I did a few refactors to merge the two implementations:
* Moved intermediateca to baseca package
* Moved extensions.go and common.go out of x509ca, since x509ca is just for pkcs11, and this caused an import cycle
* Refactored x509ca and ephemeralca to embed baseca.BaseCA, removing the duplicate CreateCertificate/Root implementations
* Renamed x509ca to pkcs11ca
* Moved VerifyCertChain to common.go, since it didn't need to be a function of baseca

The primary benefit of this refactor is that all CA implementations that use the base CA implementation will support embedded SCTs. googleca is a special case.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Refactored ephemeralca and pkcs11ca to support embedded SCTs
```
