### PR TITLE
Add Tink signing backend

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,10 @@ issues:
     linters:
     - staticcheck
     text: SA1019
+  - path: pkg/ca/tinkca/signer.go 
+    linters:
+    - staticcheck
+    text: SA1019
   max-issues-per-linter: 0
   max-same-issues: 0
 run:

--- a/cmd/create_tink_keyset/create_tink_keyset.go
+++ b/cmd/create_tink_keyset/create_tink_keyset.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/signature"
+	"github.com/sigstore/fulcio/pkg/ca/tinkca"
+)
+
+/*
+To run:
+go run cmd/create_tink_keyset/create_tink_keyset.go \
+  --kms-resource="gcp-kms://projects/<project>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>" \
+  --output="enc-keyset.cfg"
+
+You can also create a GCP KMS encrypted Tink keyset with tinkey:
+tinkey create-keyset --key-template ECDSA_P384 --out enc-keyset.cfg --master-key-uri gcp-kms://projects/<project>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>
+
+You must have the permissions to read the KMS key, and create a certificate in the CA pool.
+*/
+
+var (
+	kmsKey     = flag.String("kms-resource", "", "Resource path to KMS key, starting with gcp-kms:// or aws-kms://")
+	outputPath = flag.String("output", "", "Path to the output file")
+)
+
+func main() {
+	flag.Parse()
+	if *kmsKey == "" {
+		log.Fatal("kms-resource must be set")
+	}
+	if *outputPath == "" {
+		log.Fatal("output must be set")
+	}
+
+	kh, err := keyset.NewHandle(signature.ECDSAP384KeyWithoutPrefixTemplate())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	primaryKey, err := tinkca.GetPrimaryKey(*kmsKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f, err := os.Create(*outputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	jsonWriter := keyset.NewJSONWriter(f)
+	if err := kh.Write(jsonWriter, primaryKey); err != nil {
+		fmt.Printf("error writing primary key: %v\n", err)
+	}
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,6 +47,32 @@ Configuration:
 Be sure to run `gcloud auth application-default login` before `docker-compose up` so that
 your credentials are mounted on the container.
 
+### Tink
+
+The Tink signing backend uses an on-disk signer loaded from an encrypted Tink keyset and
+certificate chain, where the first certificate in the chain certifies the public key from
+the Tink keyset. The Tink keyset must be encrypted with a GCP KMS key, and stored in
+a JSON format. The CA can either run as an intermediate CA chaining up to an offline root CA,
+or as a root CA.
+
+**Tink keysets use strong security defaults and are the most secure way to store an encryption
+key locally.**
+
+The supported Tink keysets are:
+* ECDSA P-256, SHA256 hash
+* ECDSA P-384, SHA512 hash
+* ECDSA P-521, SHA512 hash
+* ED25519
+
+Configuration:
+* `--ca=tinkca`
+* `--tink-kms-resource=gcp-kms://<resource>`, also supporting `aws-kms://`
+* `--tink-keyset-path=/...`, a JSON-encoded encrypted Tink keyset
+* `--tink-cert-chain-path=/...`, a PEM-encoded certificate chain
+
+Be sure to run `gcloud auth application-default login` before `docker-compose up` so that
+your credentials are mounted on the container.
+
 ### Google Cloud Platform CA Service
 
 The GCP CA Service signing backend delegates creation and signing of the certificates

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/certificate-transparency-go v1.1.3
 	github.com/google/go-cmp v0.5.8
+	github.com/google/tink/go v1.6.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
@@ -85,6 +86,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-containerregistry v0.9.0 // indirect
 	github.com/google/trillian v1.4.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.36.29/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.44.22 h1:StP+vxaFzl445mSML6KzgiTcqpA+eVwbO5fMNvhVN7c=
 github.com/aws/aws-sdk-go v1.44.22/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
@@ -363,6 +364,7 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-ldap/ldap/v3 v3.1.10/go.mod h1:5Zun81jBTabRaI8lzN7E1JjyEl1g6zI6u9pd8luAK4Q=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -376,6 +378,7 @@ github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfC
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/goadesign/goa v2.2.5+incompatible h1:SLgzk0V+QfFs7MVz9sbDHelbTDI9B/d4W7Hl5udTynY=
@@ -432,6 +435,7 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -493,6 +497,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/google/tink/go v1.6.1 h1:t7JHqO8Ath2w2ig5vjwQYJzhGEZymedQc90lQXUBa4I=
+github.com/google/tink/go v1.6.1/go.mod h1:IGW53kTgag+st5yPhKKwJ6u2l+SSp5/v9XF7spovjlY=
 github.com/google/trillian v1.3.14-0.20210409160123-c5ea3abd4a41/go.mod h1:1dPv0CUjNQVFEDuAUFhZql16pw/VlPgaX8qj+g5pVzQ=
 github.com/google/trillian v1.3.14-0.20210511103300-67b5f349eefa/go.mod h1:s4jO3Ai4NSvxucdvqUHON0bCqJyoya32eNw6XJwsmNc=
 github.com/google/trillian v1.4.1 h1:r/LV2L6uq6ijSSQNSyxnLXFU/JY7DaT6AILx1sOx2+8=
@@ -557,6 +563,8 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
+github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -570,14 +578,17 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
+github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
@@ -600,6 +611,7 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -614,11 +626,14 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
 github.com/hashicorp/vault/api v1.6.0 h1:B8UUYod1y1OoiGHq9GtpiqSnGOUEWHaA26AY8RQEDY4=
 github.com/hashicorp/vault/api v1.6.0/go.mod h1:h1K70EO2DgnBaTz5IsL6D5ERsNt5Pce93ueVS2+t0Xc=
+github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/vault/sdk v0.5.0 h1:EED7p0OCU3OY5SAqJwSANofY1YKMytm+jDHDQ2EzGVQ=
 github.com/hashicorp/vault/sdk v0.5.0/go.mod h1:UJZHlfwj7qUJG8g22CuxUgkdJouFrBNvBHCyx8XAPdo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J+x6AzmKuVM/JWCQwkWm6GW/MUR6I=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/honeycombio/beeline-go v1.1.1 h1:sU8r4ae34uEL3/CguSl8Mr+Asz9DL1nfH9Wwk85Pc7U=
@@ -1350,10 +1365,12 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1453,6 +1470,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -1572,6 +1590,7 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
+google.golang.org/api v0.32.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/api v0.35.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34qYtE=
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
@@ -1619,6 +1638,7 @@ google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181107211654-5fc9ac540362/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1722,12 +1742,14 @@ google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad h1:kqrS+lhvaMHCxul6sKQvKJ8nAAhlVItmZV822hYFH/U=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
@@ -1782,6 +1804,7 @@ google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscL
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVCwMc=
+gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1802,6 +1825,7 @@ gopkg.in/linkedin/goavro.v1 v1.0.5/go.mod h1:Aw5GdAbizjOEl0kAMHV9iHmA8reZzW/OKuJ
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=

--- a/pkg/ca/tinkca/signer.go
+++ b/pkg/ca/tinkca/signer.go
@@ -1,0 +1,130 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tinkca
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"math/big"
+
+	signatureSubtle "github.com/google/tink/go/signature/subtle"
+	"github.com/google/tink/go/subtle"
+
+	"github.com/golang/protobuf/proto" //lint:ignore SA1019 needed for unmarshalling
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/keyset"
+	commonpb "github.com/google/tink/go/proto/common_go_proto"
+	ecdsapb "github.com/google/tink/go/proto/ecdsa_go_proto"
+	ed25519pb "github.com/google/tink/go/proto/ed25519_go_proto"
+	tinkpb "github.com/google/tink/go/proto/tink_go_proto"
+)
+
+var (
+	ecdsaSignerKeyVersion   = 0
+	ecdsaSignerTypeURL      = "type.googleapis.com/google.crypto.tink.EcdsaPrivateKey"
+	ed25519SignerKeyVersion = 0
+	ed25519SignerTypeURL    = "type.googleapis.com/google.crypto.tink.Ed25519PrivateKey"
+)
+
+// KeyHandleToSigner converts a key handle to the crypto.Signer interface.
+// Heavily pulls from Tink's signature and subtle packages.
+func KeyHandleToSigner(kh *keyset.Handle) (crypto.Signer, error) {
+	// extract the key material from the key handle
+	ks := insecurecleartextkeyset.KeysetMaterial(kh)
+
+	k := getPrimaryKey(ks)
+	if k == nil {
+		return nil, errors.New("no enabled key found in keyset")
+	}
+
+	switch k.GetTypeUrl() {
+	case ecdsaSignerTypeURL:
+		// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ecdsa_signer_key_manager.go#L48
+		privKey := new(ecdsapb.EcdsaPrivateKey)
+		if err := proto.Unmarshal(k.GetValue(), privKey); err != nil {
+			return nil, fmt.Errorf("error unmarshalling ecdsa private key: %w", err)
+		}
+		if err := validateEcdsaPrivKey(privKey); err != nil {
+			return nil, fmt.Errorf("error validating ecdsa private key: %w", err)
+		}
+		// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/subtle/ecdsa_signer.go#L39
+		_, curve, _ := getECDSAParamNames(privKey.PublicKey.Params)
+		p := new(ecdsa.PrivateKey)
+		c := subtle.GetCurve(curve)
+		p.PublicKey.Curve = c
+		p.D = new(big.Int).SetBytes(privKey.GetKeyValue())
+		p.PublicKey.X, p.PublicKey.Y = c.ScalarBaseMult(privKey.GetKeyValue())
+		return p, nil
+	case ed25519SignerTypeURL:
+		// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ed25519_signer_key_manager.go#L47
+		privKey := new(ed25519pb.Ed25519PrivateKey)
+		if err := proto.Unmarshal(k.GetValue(), privKey); err != nil {
+			return nil, fmt.Errorf("error unmarshalling ed25519 private key: %w", err)
+		}
+		if err := validateEd25519PrivKey(privKey); err != nil {
+			return nil, fmt.Errorf("error validating ed25519 private key: %w", err)
+		}
+		// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/subtle/ed25519_signer.go#L29
+		p := ed25519.NewKeyFromSeed(privKey.GetKeyValue())
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", k.GetTypeUrl())
+	}
+}
+
+// getPrimaryKey returns the first enabled key from a keyset.
+func getPrimaryKey(ks *tinkpb.Keyset) *tinkpb.KeyData {
+	for _, k := range ks.GetKey() {
+		if k.GetKeyId() == ks.GetPrimaryKeyId() && k.GetStatus() == tinkpb.KeyStatusType_ENABLED {
+			return k.GetKeyData()
+		}
+	}
+	return nil
+}
+
+// validateEcdsaPrivKey validates the given ECDSAPrivateKey.
+// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ecdsa_signer_key_manager.go#L139
+func validateEcdsaPrivKey(key *ecdsapb.EcdsaPrivateKey) error {
+	if err := keyset.ValidateKeyVersion(key.Version, uint32(ecdsaSignerKeyVersion)); err != nil {
+		return fmt.Errorf("ecdsa_signer_key_manager: invalid key: %w", err)
+	}
+	hash, curve, encoding := getECDSAParamNames(key.PublicKey.Params)
+	return signatureSubtle.ValidateECDSAParams(hash, curve, encoding)
+}
+
+// getECDSAParamNames returns the string representations of each parameter in
+// the given ECDSAParams.
+// https://github.com/google/tink/blob/4cc630dfc711555f6bbbad64f8c573b39b7af500/go/signature/proto.go#L26
+func getECDSAParamNames(params *ecdsapb.EcdsaParams) (string, string, string) {
+	hashName := commonpb.HashType_name[int32(params.HashType)]
+	curveName := commonpb.EllipticCurveType_name[int32(params.Curve)]
+	encodingName := ecdsapb.EcdsaSignatureEncoding_name[int32(params.Encoding)]
+	return hashName, curveName, encodingName
+}
+
+// validateEd25519PrivKey validates the given ED25519PrivateKey.
+// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ed25519_signer_key_manager.go#L132
+func validateEd25519PrivKey(key *ed25519pb.Ed25519PrivateKey) error {
+	if err := keyset.ValidateKeyVersion(key.Version, uint32(ed25519SignerKeyVersion)); err != nil {
+		return fmt.Errorf("ed25519_signer_key_manager: invalid key: %w", err)
+	}
+	if len(key.KeyValue) != ed25519.SeedSize {
+		return fmt.Errorf("ed2219_signer_key_manager: invalid key length, got %d", len(key.KeyValue))
+	}
+	return nil
+}

--- a/pkg/ca/tinkca/signer_test.go
+++ b/pkg/ca/tinkca/signer_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tinkca
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+	"testing"
+
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/proto/tink_go_proto"
+	"github.com/google/tink/go/signature"
+)
+
+type TestStruct struct {
+	keyTemplate *tink_go_proto.KeyTemplate
+	h           hash.Hash
+}
+
+func TestKeyHandleToSignerECDSA(t *testing.T) {
+	supportedKeyTypes := []TestStruct{
+		{
+			keyTemplate: signature.ECDSAP256KeyWithoutPrefixTemplate(),
+			h:           sha256.New(),
+		},
+		{
+			keyTemplate: signature.ECDSAP384KeyWithoutPrefixTemplate(),
+			h:           sha512.New(),
+		},
+		{
+			keyTemplate: signature.ECDSAP521KeyWithoutPrefixTemplate(),
+			h:           sha512.New(),
+		},
+	}
+	for _, kt := range supportedKeyTypes {
+		kh, err := keyset.NewHandle(kt.keyTemplate)
+		if err != nil {
+			t.Fatalf("error creating ECDSA key handle: %v", err)
+		}
+		// convert to crypto.Signer interface
+		signer, err := KeyHandleToSigner(kh)
+		if err != nil {
+			t.Fatalf("error converting ECDSA key handle to signer: %v", err)
+		}
+		msg := []byte("hello there")
+
+		// sign with key handle, verify with signer public key
+		tinkSigner, err := signature.NewSigner(kh)
+		if err != nil {
+			t.Fatalf("error creating tink signer: %v", err)
+		}
+		sig, err := tinkSigner.Sign(msg)
+		if err != nil {
+			t.Fatalf("error signing with tink signer: %v", err)
+		}
+		kt.h.Write(msg)
+		digest := kt.h.Sum(nil)
+		if !ecdsa.VerifyASN1(signer.Public().(*ecdsa.PublicKey), digest, sig) {
+			t.Fatalf("signature from tink signer did not match")
+		}
+
+		// sign with signer, verify with key handle
+		sig, err = ecdsa.SignASN1(rand.Reader, signer.(*ecdsa.PrivateKey), digest)
+		if err != nil {
+			t.Fatalf("error signing with crypto signer: %v", err)
+		}
+		pubkh, err := kh.Public()
+		if err != nil {
+			t.Fatalf("error fetching public key handle: %v", err)
+		}
+		v, err := signature.NewVerifier(pubkh)
+		if err != nil {
+			t.Fatalf("error creating tink verifier: %v", err)
+		}
+		if err := v.Verify(sig, msg); err != nil {
+			t.Fatalf("error verifying with tink verifier: %v", err)
+		}
+	}
+}
+
+func TestKeyHandleToSignerED25519(t *testing.T) {
+	kh, err := keyset.NewHandle(signature.ED25519KeyWithoutPrefixTemplate())
+	if err != nil {
+		t.Fatalf("error creating ED25519 key handle: %v", err)
+	}
+	// convert to crypto.Signer interface
+	signer, err := KeyHandleToSigner(kh)
+	if err != nil {
+		t.Fatalf("error converting ED25519 key handle to signer: %v", err)
+	}
+	msg := []byte("hello there")
+
+	// sign with key handle, verify with signer public key
+	tinkSigner, err := signature.NewSigner(kh)
+	if err != nil {
+		t.Fatalf("error creating tink signer: %v", err)
+	}
+	sig, err := tinkSigner.Sign(msg)
+	if err != nil {
+		t.Fatalf("error signing with tink signer: %v", err)
+	}
+	if !ed25519.Verify(signer.Public().(ed25519.PublicKey), msg, sig) {
+		t.Fatalf("signature from tink signer did not match")
+	}
+
+	// sign with signer, verify with key handle
+	sig = ed25519.Sign(signer.(ed25519.PrivateKey), msg)
+	if err != nil {
+		t.Fatalf("error signing with crypto signer: %v", err)
+	}
+	pubkh, err := kh.Public()
+	if err != nil {
+		t.Fatalf("error fetching public key handle: %v", err)
+	}
+	v, err := signature.NewVerifier(pubkh)
+	if err != nil {
+		t.Fatalf("error creating tink verifier: %v", err)
+	}
+	if err := v.Verify(sig, msg); err != nil {
+		t.Fatalf("error verifying with tink verifier: %v", err)
+	}
+}

--- a/pkg/ca/tinkca/tinkca.go
+++ b/pkg/ca/tinkca/tinkca.go
@@ -1,0 +1,110 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tinkca
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sigstore/fulcio/pkg/ca"
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+
+	"github.com/google/tink/go/core/registry"
+	"github.com/google/tink/go/integration/awskms"
+	"github.com/google/tink/go/integration/gcpkms"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/tink"
+)
+
+type tinkCA struct {
+	baseca.BaseCA
+}
+
+// NewTinkCA creates a signer from an encrypted Tink keyset, encrypted with a GCP KMS key.
+func NewTinkCA(ctx context.Context, kmsKey, tinkKeysetPath, certPath string) (ca.CertificateAuthority, error) {
+	primaryKey, err := GetPrimaryKey(kmsKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTinkCAFromHandle(ctx, tinkKeysetPath, certPath, primaryKey)
+}
+
+// NewTinkCAFromHandle creates a signer from an encrypted Tink keyset, encrypted with an AEAD key.
+func NewTinkCAFromHandle(ctx context.Context, tinkKeysetPath, certPath string, primaryKey tink.AEAD) (ca.CertificateAuthority, error) {
+	var tca tinkCA
+
+	f, err := os.Open(filepath.Clean(tinkKeysetPath))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	kh, err := keyset.Read(keyset.NewJSONReader(f), primaryKey)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := KeyHandleToSigner(kh)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := ca.SignerCerts{}
+	tca.SignerWithChain = &sc
+
+	sc.Signer = signer
+
+	data, err := os.ReadFile(filepath.Clean(certPath))
+	if err != nil {
+		return nil, err
+	}
+	sc.Certs, err = cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	if err := ca.VerifyCertChain(sc.Certs, sc.Signer); err != nil {
+		return nil, err
+	}
+
+	return &tca, nil
+}
+
+// GetPrimaryKey returns a Tink AEAD encryption key from KMS
+// Supports GCP and AWS
+func GetPrimaryKey(kmsKey string) (tink.AEAD, error) {
+	switch {
+	case strings.HasPrefix(kmsKey, "gcp-kms://"):
+		gcpClient, err := gcpkms.NewClient(kmsKey)
+		if err != nil {
+			return nil, err
+		}
+		registry.RegisterKMSClient(gcpClient)
+		return gcpClient.GetAEAD(kmsKey)
+	case strings.HasPrefix(kmsKey, "aws-kms://"):
+		awsClient, err := awskms.NewClient(kmsKey)
+		if err != nil {
+			return nil, err
+		}
+		registry.RegisterKMSClient(awsClient)
+		return awsClient.GetAEAD(kmsKey)
+	default:
+		return nil, errors.New("unsupported KMS key type")
+	}
+}

--- a/pkg/ca/tinkca/tinkca_test.go
+++ b/pkg/ca/tinkca/tinkca_test.go
@@ -1,0 +1,141 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tinkca
+
+import (
+	"context"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/signature"
+	"github.com/sigstore/fulcio/pkg/test"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
+)
+
+func TestNewTinkCA(t *testing.T) {
+	aeskh, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	if err != nil {
+		t.Fatalf("error creating AEAD key handle: %v", err)
+	}
+	a, err := aead.New(aeskh)
+	if err != nil {
+		t.Fatalf("error creating AEAD key: %v", err)
+	}
+
+	kh, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
+	if err != nil {
+		t.Fatalf("error creating ECDSA key handle: %v", err)
+	}
+	khsigner, err := KeyHandleToSigner(kh)
+	if err != nil {
+		t.Fatalf("error converting ECDSA key handle to signer: %v", err)
+	}
+
+	rootCert, _ := test.GenerateRootCAFromSigner(khsigner)
+	pemChain, err := cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{rootCert})
+	if err != nil {
+		t.Fatalf("error marshalling cert chain: %v", err)
+	}
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	err = os.WriteFile(certPath, pemChain, 0600)
+	if err != nil {
+		t.Fatalf("error writing pem chain: %v", err)
+	}
+
+	keysetPath := filepath.Join(dir, "keyset.json.enc")
+	f, err := os.Create(keysetPath)
+	if err != nil {
+		t.Fatalf("error creating file: %v", err)
+	}
+	defer f.Close()
+	jsonWriter := keyset.NewJSONWriter(f)
+	if err := kh.Write(jsonWriter, a); err != nil {
+		t.Fatalf("error writing enc keyset: %v", err)
+	}
+
+	ca, err := NewTinkCAFromHandle(context.TODO(), keysetPath, certPath, a)
+	if err != nil {
+		t.Fatalf("unexpected error creating KMS CA: %v", err)
+	}
+
+	// Expect certificate chain from Root matches provided certificate chain
+	rootBytes, err := ca.Root(context.TODO())
+	if err != nil {
+		t.Fatalf("error fetching root: %v", err)
+	}
+	if !reflect.DeepEqual(rootBytes, pemChain) {
+		t.Fatal("cert chains do not match")
+	}
+
+	// Expect signer and certificate's public keys match
+	certs, signer := ca.(*tinkCA).GetSignerWithChain()
+	if err := cryptoutils.EqualKeys(signer.Public(), khsigner.Public()); err != nil {
+		t.Fatalf("keys between CA and signer do not match: %v", err)
+	}
+	if !reflect.DeepEqual(certs, []*x509.Certificate{rootCert}) {
+		t.Fatalf("expected certificate chains to match")
+	}
+
+	// Failure: Mismatch between signer and certificate key
+	otherRootCert, _, _ := test.GenerateRootCA()
+	pemChain, err = cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{otherRootCert})
+	if err != nil {
+		t.Fatalf("error marshalling cert chain: %v", err)
+	}
+	err = os.WriteFile(certPath, pemChain, 0600)
+	if err != nil {
+		t.Fatalf("error writing pem chain: %v", err)
+	}
+	_, err = NewTinkCAFromHandle(context.TODO(), keysetPath, certPath, a)
+	if err == nil || !strings.Contains(err.Error(), "ecdsa public keys are not equal") {
+		t.Fatalf("expected error with mismatched public keys, got %v", err)
+	}
+
+	// Failure: Invalid certificate chain
+	pemChain, err = cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{rootCert, otherRootCert})
+	if err != nil {
+		t.Fatalf("error marshalling cert chain: %v", err)
+	}
+	err = os.WriteFile(certPath, pemChain, 0600)
+	if err != nil {
+		t.Fatalf("error writing pem chain: %v", err)
+	}
+	_, err = NewTinkCAFromHandle(context.TODO(), keysetPath, certPath, a)
+	if err == nil || !strings.Contains(err.Error(), "certificate signed by unknown authority") {
+		t.Fatalf("expected error with invalid certificate chain, got %v", err)
+	}
+
+	// Failure: Unable to decrypt keyset
+	aeskh1, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	if err != nil {
+		t.Fatalf("error creating AEAD key handle: %v", err)
+	}
+	a1, err := aead.New(aeskh1)
+	if err != nil {
+		t.Fatalf("error creating AEAD key: %v", err)
+	}
+	_, err = NewTinkCAFromHandle(context.TODO(), keysetPath, certPath, a1)
+	if err == nil || !strings.Contains(err.Error(), "decryption failed") {
+		t.Fatalf("expected error decrypting keyset, got %v", err)
+	}
+}

--- a/pkg/test/cert_utils.go
+++ b/pkg/test/cert_utils.go
@@ -87,6 +87,28 @@ func GenerateRootCA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	return cert, priv, nil
 }
 
+func GenerateRootCAFromSigner(signer crypto.Signer) (*x509.Certificate, error) {
+	rootTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "sigstore",
+			Organization: []string{"sigstore.dev"},
+		},
+		NotBefore:             time.Now().Add(-5 * time.Minute),
+		NotAfter:              time.Now().Add(5 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	cert, err := createCertificate(rootTemplate, rootTemplate, signer.Public(), signer)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}
+
 func GenerateSubordinateCA(rootTemplate *x509.Certificate, rootPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	subTemplate := &x509.Certificate{
 		SerialNumber: big.NewInt(1),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This adds support for using encrypted Tink keysets to load a signer.
There are two main benefits from this work: We can leverage this instead
of KMS if we need to support a higher QPS, and Tink keysets use strong
secure defaults. Keysets can be encrypted with AESGCM, do not rely on a
KDF, cannot be brute-forced, and access to the key can be audited
through cloud audit logs.

Tink does not provide a method to extract the signing key from the
keyset intentionally, so I wrote a helper library to reach into the key
handle proto to construct a crypto.Signer.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #646

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added Tink signing backend for signing certificates with a local encrypted Tink keyset
```
