### PR TITLE
pipe all log messages to stdout for dev logger

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -44,6 +44,7 @@ func ConfigureLogger(logType string) {
 	} else {
 		cfg = zap.NewDevelopmentConfig()
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		cfg.OutputPaths = []string{"stdout"}
 	}
 	logger, err := cfg.Build()
 	if err != nil {


### PR DESCRIPTION
Confirmed with `docker logs -f fulcio-server 2>/dev/null`

This only fixes the development logger, not the prod one.

Fixes #641 

Signed-off-by: Bob Callaway <bcallaway@google.com>
