### PR TITLE
bump cosign to v1.9.0

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.18.3-0@sha256:d4614e3a12fd43b1ef29252d1add330c0b496b5313eda37975d4a87815a6ae90
-      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c
+      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.9.0@sha256:ef2d14e16dbb7786d8713e4898a8512e69ace4105f5b371a9c115ffcc3e85d84
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3


### PR DESCRIPTION
This fixes errors reported in CI due to using back-level cosign.

https://github.com/sigstore/fulcio/runs/7401355413?check_suite_focus=true

Signed-off-by: Bob Callaway <bcallaway@google.com>
