### PR TITLE
address Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,7 +56,7 @@ jobs:
         timeout-minutes: 5
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46.0
+          version: v1.48.0
 
   oidc-config:
     name: oidc-config


### PR DESCRIPTION
#### Summary
- address Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
- update golangci-lint to 1.48.0

#### Release Note
- address Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server 
