### PR TITLE
Clean up unix socket

### DIFF
--- a/cmd/app/grpc.go
+++ b/cmd/app/grpc.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/goadesign/goa/grpc/middleware"
 	ctclient "github.com/google/certificate-transparency-go/client"
@@ -108,6 +109,10 @@ func (g *grpcServer) startTCPListener() {
 
 func (g *grpcServer) startUnixListener() {
 	go func() {
+		if err := os.RemoveAll(LegacyUnixDomainSocket); err != nil {
+			log.Logger.Fatal(err)
+		}
+
 		unixAddr, err := net.ResolveUnixAddr("unix", LegacyUnixDomainSocket)
 		if err != nil {
 			log.Logger.Fatal(err)

--- a/cmd/app/grpc.go
+++ b/cmd/app/grpc.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 
 	"github.com/goadesign/goa/grpc/middleware"
 	ctclient "github.com/google/certificate-transparency-go/client"
@@ -109,8 +110,12 @@ func (g *grpcServer) startTCPListener() {
 
 func (g *grpcServer) startUnixListener() {
 	go func() {
-		if err := os.RemoveAll(LegacyUnixDomainSocket); err != nil {
-			log.Logger.Fatal(err)
+		if runtime.GOOS != "linux" {
+			// As MacOS doesn't have abstract unix domain sockets the file
+			// created by a previous run needs to be explicitly removed
+			if err := os.RemoveAll(LegacyUnixDomainSocket); err != nil {
+				log.Logger.Fatal(err)
+			}
 		}
 
 		unixAddr, err := net.ResolveUnixAddr("unix", LegacyUnixDomainSocket)


### PR DESCRIPTION
On MacOS it seems subsequent attempts to bind to the abstract Unix
socket fail without first explicitly removing it. This issue seems to be
MacOS-specific as it doesn't occur on an Ubuntu VM (using `lima`).

Fixes sigstore/fulcio#738

Signed-off-by: Paul Thomson <thomsonp83@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->