### PR TITLE
adding tuf root env variable

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -56,6 +56,7 @@ steps:
   - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   - COSIGN_EXPERIMENTAL=true
   - KO_PREFIX=gcr.io/${PROJECT_ID}
+  - TUF_ROOT=/tmp
   secretEnv:
   - GITHUB_TOKEN
   args:
@@ -80,6 +81,7 @@ steps:
   - COSIGN_EXPERIMENTAL=true
   - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   - GITHUB_USER=${_GITHUB_USER}
+  - TUF_ROOT=/tmp
   secretEnv:
   - GITHUB_TOKEN
   args:


### PR DESCRIPTION

#### Summary
Getting this error while doing the release

```
Step #3:   ⨯ release failed after 4m47s                       error=sign: cosign failed: exit status 1: Using payload from: /workspace/go/src/sigstore/fulcio/dist/fulcio-linux-ppc64le
Step #3: Generating ephemeral keys...
Step #3: Retrieving signed certificate...
Step #3: 
Step #3:         Note that there may be personally identifiable information associated with this signed artifact.
Step #3:         This may include the email address associated with the account with which you authenticate.
Step #3:         This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
Step #3: Error: signing /workspace/go/src/sigstore/fulcio/dist/fulcio-linux-ppc64le: getting key from Fulcio: verifying SCT: creating cached local store: resource temporarily unavailable
Step #3: main.go:62: error during command execution: signing /workspace/go/src/sigstore/fulcio/dist/fulcio-linux-ppc64le: getting key from Fulcio: verifying SCT: creating cached local store: resource temporarily unavailable
Step #3: 
```

saw a similar issue sometime ago and defining the TUF_ROOT seems to fix the issue



