### PR TITLE
use same way to output version and expose build info to prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,9 @@ GIT_HASH ?= $(shell git rev-parse HEAD)
 GIT_TAG ?= dirty-tag
 DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
-ifdef SOURCE_DATE_EPOCH
-    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
-else
-    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
-endif
-GIT_TREESTATE = "clean"
-DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
-ifeq ($(DIFF), 1)
-    GIT_TREESTATE = "dirty"
-endif
 
-FULCIO_VERSION_PKG=github.com/sigstore/fulcio/pkg/server
-LDFLAGS=-X $(FULCIO_VERSION_PKG).gitVersion=$(GIT_VERSION) -X $(FULCIO_VERSION_PKG).gitCommit=$(GIT_HASH) -X $(FULCIO_VERSION_PKG).gitTreeState=$(GIT_TREESTATE) -X $(FULCIO_VERSION_PKG).buildDate=$(BUILD_DATE)
+FULCIO_VERSION_PKG=sigs.k8s.io/release-utils/version
+LDFLAGS=-X $(FULCIO_VERSION_PKG).gitVersion=$(GIT_VERSION)
 
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)

--- a/cmd/app/root.go
+++ b/cmd/app/root.go
@@ -43,5 +43,4 @@ func Execute(ctx context.Context) {
 func init() {
 	rootCmd.AddCommand(newCreateCACmd())
 	rootCmd.AddCommand(newServeCmd())
-	rootCmd.AddCommand(newVersionCmd())
 }

--- a/cmd/app/version.go
+++ b/cmd/app/version.go
@@ -16,44 +16,9 @@
 package app
 
 import (
-	"fmt"
-
-	"github.com/sigstore/fulcio/pkg/server"
-	"github.com/spf13/cobra"
+	"sigs.k8s.io/release-utils/version"
 )
 
-type versionOptions struct {
-	json bool
-}
-
-var versionOpts = &versionOptions{}
-
-func newVersionCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "print build version",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersion(versionOpts)
-		},
-	}
-
-	cmd.Flags().BoolVarP(&versionOpts.json, "json", "j", false, "print JSON instead of text")
-
-	return cmd
-}
-
-func runVersion(opts *versionOptions) error {
-	v := server.VersionInfo()
-	res := v.String()
-
-	if opts.json {
-		j, err := v.JSONString()
-		if err != nil {
-			return fmt.Errorf("unable to generate JSON from version info: %w", err)
-		}
-		res = j
-	}
-
-	fmt.Println(res)
-	return nil
+func init() {
+	rootCmd.AddCommand(version.Version())
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/release-utils v0.7.3
 )
 
 require (
@@ -81,6 +82,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 // indirect
 	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490 // indirect
+	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -1829,6 +1831,8 @@ pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/release-utils v0.7.3 h1:6pS8x6c5RmdUgR9qcg1LO6hjUzuE4Yo9TGZ3DemrZdM=
+sigs.k8s.io/release-utils v0.7.3/go.mod h1:n0mVez/1PZYZaZUTJmxewxH3RJ/Lf7JUDh7TG1CASOE=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -18,6 +18,7 @@ package server
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/release-utils/version"
 )
 
 var (
@@ -35,4 +36,19 @@ var (
 		Name: "http_requests_total",
 		Help: "Count all HTTP requests",
 	}, []string{"code", "method"})
+
+	_ = promauto.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: "fulcio",
+			Name:      "build_info",
+			Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which rekor was built.",
+			ConstLabels: prometheus.Labels{
+				"version":    version.GetVersionInfo().GitVersion,
+				"revision":   version.GetVersionInfo().GitCommit,
+				"build_date": version.GetVersionInfo().BuildDate,
+				"goversion":  version.GetVersionInfo().GoVersion,
+			},
+		},
+		func() float64 { return 1 },
+	)
 )


### PR DESCRIPTION
#### Summary
- export fulcio build/version information
- use the same way to expose version information as we use in rekor and other projects

with this, we can add a dashboard to see what version we have deployed and also can be used to compare between environments which I saw a issue around but was not able to find it

also fixes partially: https://github.com/sigstore/public-good-instance/issues/714

```
# HELP rekor_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which rekor was built.
# TYPE fulcio_build_info gauge
fulcio_build_info{build_date="2022-10-07T16:22:46",goversion="go1.19.2",revision="f2f24ac39392e366949a50972c8851bde2d39b7a",version="v0.6.0-9-gf2f24ac"} 1
```


