### PR TITLE
fix race condition in unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Test
+        # remove these environment variables after issue #840 is resolved
+        env:
+          GRPC_GO_LOG_VERBOSITY_LEVEL: 99
+          GRPC_GO_LOG_SEVERITY_LEVEL: info
         run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload Coverage Report
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,6 @@ jobs:
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Test
-        # remove these environment variables after issue #840 is resolved
-        env:
-          GRPC_GO_LOG_VERBOSITY_LEVEL: 99
-          GRPC_GO_LOG_SEVERITY_LEVEL: info
         run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload Coverage Report
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/cmd/app/http_test.go
+++ b/cmd/app/http_test.go
@@ -60,7 +60,7 @@ func setupHTTPServer(t *testing.T) (httpServer, string) {
 	}
 
 	httpHost := httpListen.Addr().String()
-	httpServer := createHTTPServer(context.Background(), httpListen.Addr().String(), grpcServer, nil)
+	httpServer := createHTTPServer(context.Background(), httpHost, grpcServer, nil)
 	go func() {
 		_ = httpServer.Serve(httpListen)
 		grpcServer.GracefulStop()


### PR DESCRIPTION
`grpcServerEndpoint` could be read at any point depending on goroutine scheduling. Sometimes that read occurred (appearing intermittently in CI testing) after memory for a string was allocated but before the string value was populated with non-null bytes, leading to issues as reported in #840. 

This reduces the scope of what is run within the go routine when launching the grpc server.

Fixes: #840 

