### PR TITLE
Fix bugs in googleca and update flag description

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -60,7 +60,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().String("log_type", "dev", "logger type to use (dev/prod)")
 	cmd.Flags().String("ca", "", "googleca | tinkca | pkcs11ca | fileca | kmsca | ephemeralca (for testing)")
 	cmd.Flags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
-	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: /projects/<project>/locations/<location>/<name> (only used with --ca googleca)")
+	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool>/certificateAuthorities/<certificateAuthority> (only used with --ca googleca)")
 	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
 	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
 	cmd.Flags().String("ct-log-public-key-path", "", "Path to a PEM-encoded public key of the CT log, used to verify SCTs")

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -61,7 +61,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().String("ca", "", "googleca | tinkca | pkcs11ca | fileca | kmsca | ephemeralca (for testing)")
 	cmd.Flags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
 	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool> (only used with --ca googleca)"+
-		"Optionally specify /certificateAuthorities/*, which will bypass CA pool load balancing.")
+		"Optionally specify /certificateAuthorities/<caID>, which will bypass CA pool load balancing.")
 	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
 	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
 	cmd.Flags().String("ct-log-public-key-path", "", "Path to a PEM-encoded public key of the CT log, used to verify SCTs")

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -60,7 +60,8 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().String("log_type", "dev", "logger type to use (dev/prod)")
 	cmd.Flags().String("ca", "", "googleca | tinkca | pkcs11ca | fileca | kmsca | ephemeralca (for testing)")
 	cmd.Flags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
-	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool> (only used with --ca googleca)")
+	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool> (only used with --ca googleca)"+
+		"Optionally specify /certificateAuthorities/*, which will bypass CA pool load balancing.")
 	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
 	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
 	cmd.Flags().String("ct-log-public-key-path", "", "Path to a PEM-encoded public key of the CT log, used to verify SCTs")

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -60,7 +60,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().String("log_type", "dev", "logger type to use (dev/prod)")
 	cmd.Flags().String("ca", "", "googleca | tinkca | pkcs11ca | fileca | kmsca | ephemeralca (for testing)")
 	cmd.Flags().String("aws-hsm-root-ca-path", "", "Path to root CA on disk (only used with AWS HSM)")
-	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool>/certificateAuthorities/<certificateAuthority> (only used with --ca googleca)")
+	cmd.Flags().String("gcp_private_ca_parent", "", "private ca parent: projects/<project>/locations/<location>/caPools/<caPool> (only used with --ca googleca)")
 	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
 	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
 	cmd.Flags().String("ct-log-public-key-path", "", "Path to a PEM-encoded public key of the CT log, used to verify SCTs")


### PR DESCRIPTION
This fixes 2 bugs in the googleca:
1. We would always fail in `TrustBundle` because we were checking `if len(roots) == 0` instead of `if len(caCerts) == 0`, roots was always empty at this point
2. Allow specifying certificateAuthority in the `gcp_private_ca_parent ` flag


Signed-off-by: Priya Wadhwa <priya@chainguard.dev>


#### Release Note
Fix bugs in googleca and update flag description
