### PR TITLE
Fix pkcs11ca with no cgo compilation bug

### DIFF
--- a/pkg/ca/pkcs11ca/pkcs11canocgo.go
+++ b/pkg/ca/pkcs11ca/pkcs11canocgo.go
@@ -20,7 +20,13 @@ package pkcs11ca
 
 import (
 	"errors"
+
+	"github.com/sigstore/fulcio/pkg/ca/baseca"
 )
+
+type PKCS11CA struct {
+	baseca.BaseCA
+}
 
 type Params struct {
 	ConfigPath string


### PR DESCRIPTION
Was seeing this bug on my M1 when running `ko build .`, since `PKCS11CA` needs to be redefined for the no-cgo case. The error was:

```
$ ko build .

pkg/ca/pkcs11ca/pkcs11canocgo.go:26:2: undefined: baseca
```

We define `type PKCS11CA struct` for the cgo case here, so this just does the same for the no-cgo case:

https://github.com/sigstore/fulcio/blob/81ecec8bb8bc0cd1f42fc445e48854167f19bc7d/pkg/ca/pkcs11ca/pkcs11ca.go#L39-L41

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

