### PR TITLE
Refactor kmsca constructor to accept x509.Certificates

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -18,6 +18,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"net/http"
@@ -213,11 +214,13 @@ func runServeCmd(cmd *cobra.Command, args []string) {
 	case "ephemeralca":
 		baseca, err = ephemeralca.NewEphemeralCA()
 	case "kmsca":
-		data, err := os.ReadFile(filepath.Clean(viper.GetString("kms-cert-chain-path")))
+		var data []byte
+		data, err = os.ReadFile(filepath.Clean(viper.GetString("kms-cert-chain-path")))
 		if err != nil {
 			log.Logger.Fatalf("error reading the kms certificate chain from '%s': %v", viper.GetString("kms-cert-chain-path"), err)
 		}
-		certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(data))
+		var certs []*x509.Certificate
+		certs, err = cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(data))
 		if err != nil {
 			log.Logger.Fatalf("error loading the PEM certificates from the kms certificate chain from '%s': %v", viper.GetString("kms-cert-chain-path"), err)
 		}


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR aims to refactor the KMSCA constructor to accept an array of x509 certificates instead of a file path. This makes this function more reusable, as well as it moves the processing of the viper flags to the cmd pkg.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->