### PR TITLE
Expose RPC options to set oidc auth creds for KMS

### DIFF
--- a/pkg/ca/kmsca/kmsca.go
+++ b/pkg/ca/kmsca/kmsca.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/ca/baseca"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
 
 	// Register the provider-specific plugins
@@ -35,10 +36,10 @@ type kmsCA struct {
 	baseca.BaseCA
 }
 
-func NewKMSCA(ctx context.Context, kmsKey string, certs []*x509.Certificate) (ca.CertificateAuthority, error) {
+func NewKMSCA(ctx context.Context, kmsKey string, certs []*x509.Certificate, opts ...signature.RPCOption) (ca.CertificateAuthority, error) {
 	var ica kmsCA
 
-	kmsSigner, err := kms.Get(ctx, kmsKey, crypto.SHA256)
+	kmsSigner, err := kms.Get(ctx, kmsKey, crypto.SHA256, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
I realized I needed to pass in some extra RPC options (e.g. OIDC Auth). This just exposes all the  RPC options so that folks using this as a library can pass them in.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->