### PR TITLE
update builder release to use go 1.19.5 and refactor validate release job

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -19,49 +19,39 @@ on:
   push:
     branches:
       - main
-      - release-*
+      - 'release-**'
   pull_request:
 
+permissions: {}
+
 jobs:
+  check-signature:
+    runs-on: ubuntu-latest
+    container:
+      image: gcr.io/projectsigstore/cosign:v1.13.1@sha256:fd5b09be23ef1027e1bdd490ce78dcc65d2b15902e1f4ba8e04f3b4019cc1057
+
+    steps:
+      - name: Check Signature
+        run: cosign verify ghcr.io/gythialy/golang-cross:v1.19.5-0@sha256:76716805e9d07712f0628c36d21223874b1dd9af5e5de2d00325c00b24b238cc
+        env:
+          COSIGN_EXPERIMENTAL: true
+          TUF_ROOT: /tmp
+
   validate-release-job:
     runs-on: ubuntu-latest
-
-    # disable all permissions
-    permissions: {}
-
-    env:
-      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.19.4-0@sha256:53ee894818ac14377996a6fe7c8fe6156d018a20f82aaf69f2519fc45d897bec
-      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.13.1@sha256:fd5b09be23ef1027e1bdd490ce78dcc65d2b15902e1f4ba8e04f3b4019cc1057
+    needs:
+      - check-signature
+    container:
+      image: ghcr.io/gythialy/golang-cross:v1.19.5-0@sha256:76716805e9d07712f0628c36d21223874b1dd9af5e5de2d00325c00b24b238cc
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Extract version of Go to use
-        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
-      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: ${{ env.GOVERSION }}
-
-      - name: Check Signature
-        run: |
-          docker run --rm \
-          -e COSIGN_EXPERIMENTAL=true \
-          -e TUF_ROOT=/tmp \
-          $COSIGN_IMAGE \
-          verify \
-          $CROSS_BUILDER_IMAGE
 
       - name: goreleaser snapshot
-        run: |
-          docker run --rm --privileged \
-          -e PROJECT_ID=honk-fake-project \
-          -e CI=$CI \
-          -e RUNTIME_IMAGE=gcr.io/distroless/static:debug-nonroot \
-          -v ${PWD}:/go/src/sigstore/fulcio \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          -w /go/src/sigstore/fulcio \
-          --entrypoint="" \
-          $CROSS_BUILDER_IMAGE \
-          make snapshot
+        run: make snapshot
+        env:
+          PROJECT_ID: honk-fake-project
+          RUNTIME_IMAGE: gcr.io/distroless/static:debug-nonroot
 
       - name: check binaries
         run: |

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -39,9 +39,9 @@ steps:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.19.4-0@sha256:53ee894818ac14377996a6fe7c8fe6156d018a20f82aaf69f2519fc45d897bec'
+      - 'ghcr.io/gythialy/golang-cross:v1.19.5-0@sha256:76716805e9d07712f0628c36d21223874b1dd9af5e5de2d00325c00b24b238cc'
 
-  - name: ghcr.io/gythialy/golang-cross:v1.19.4-0@sha256:53ee894818ac14377996a6fe7c8fe6156d018a20f82aaf69f2519fc45d897bec
+  - name: ghcr.io/gythialy/golang-cross:v1.19.5-0@sha256:76716805e9d07712f0628c36d21223874b1dd9af5e5de2d00325c00b24b238cc
     entrypoint: /bin/sh
     dir: "go/src/sigstore/fulcio"
     env:
@@ -65,7 +65,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.19.4-0@sha256:53ee894818ac14377996a6fe7c8fe6156d018a20f82aaf69f2519fc45d897bec
+  - name: ghcr.io/gythialy/golang-cross:v1.19.5-0@sha256:76716805e9d07712f0628c36d21223874b1dd9af5e5de2d00325c00b24b238cc
     entrypoint: 'bash'
     dir: "go/src/sigstore/fulcio"
     env:


### PR DESCRIPTION
#### Summary
- update builder release to use go 1.19.5 and refactor validate release job