### PR TITLE
Add GitLab.com OIDC to Fulcio

### DIFF
--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -33,6 +33,11 @@ data:
               "Type": "spiffe",
               "SPIFFETrustDomain": "allow.pub"
             },
+            "https://gitlab.com": {
+              "IssuerURL": "https://gitlab.com",
+              "ClientID": "sigstore",
+              "Type": "gitlab-pipeline"
+            },
             "https://oauth2.sigstore.dev/auth": {
               "IssuerURL": "https://oauth2.sigstore.dev/auth",
               "ClientID": "sigstore",

--- a/federation/gitlab.com/config.yaml
+++ b/federation/gitlab.com/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: https://gitlab.com
+contact: support@gitlab.com
+description: "GitLab OIDC tokens for job identity"
+type: "gitlab-pipeline"

--- a/pkg/challenges/challenges.go
+++ b/pkg/challenges/challenges.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sigstore/fulcio/pkg/identity/buildkite"
 	"github.com/sigstore/fulcio/pkg/identity/email"
 	"github.com/sigstore/fulcio/pkg/identity/github"
+	"github.com/sigstore/fulcio/pkg/identity/gitlabcom"
 	"github.com/sigstore/fulcio/pkg/identity/kubernetes"
 	"github.com/sigstore/fulcio/pkg/identity/spiffe"
 	"github.com/sigstore/fulcio/pkg/identity/uri"
@@ -60,6 +61,8 @@ func PrincipalFromIDToken(ctx context.Context, tok *oidc.IDToken) (identity.Prin
 	switch iss.Type {
 	case config.IssuerTypeBuildkiteJob:
 		principal, err = buildkite.JobPrincipalFromIDToken(ctx, tok)
+	case config.IssuerTypeGitLabPipeline:
+		principal, err = gitlabcom.JobPrincipalFromIDToken(ctx, tok)
 	case config.IssuerTypeEmail:
 		principal, err = email.PrincipalFromIDToken(ctx, tok)
 	case config.IssuerTypeSpiffe:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,7 @@ const (
 	IssuerTypeBuildkiteJob   = "buildkite-job"
 	IssuerTypeEmail          = "email"
 	IssuerTypeGithubWorkflow = "github-workflow"
+	IssuerTypeGitLabPipeline = "gitlab-pipeline"
 	IssuerTypeKubernetes     = "kubernetes"
 	IssuerTypeSpiffe         = "spiffe"
 	IssuerTypeURI            = "uri"
@@ -467,6 +468,8 @@ func issuerToChallengeClaim(issType IssuerType, challengeClaim string) string {
 	}
 	switch issType {
 	case IssuerTypeBuildkiteJob:
+		return "sub"
+	case IssuerTypeGitLabPipeline:
 		return "sub"
 	case IssuerTypeEmail:
 		return "email"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -489,6 +489,9 @@ func Test_issuerToChallengeClaim(t *testing.T) {
 	if claim := issuerToChallengeClaim(IssuerTypeGithubWorkflow, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for GitHub issuer, got %s", claim)
 	}
+	if claim := issuerToChallengeClaim(IssuerTypeGitLabPipeline, ""); claim != "sub" {
+		t.Fatalf("expected sub subject claim for GitLab issuer, got %s", claim)
+	}
 	if claim := issuerToChallengeClaim(IssuerTypeKubernetes, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for K8S issuer, got %s", claim)
 	}

--- a/pkg/identity/gitlabcom/issuer.go
+++ b/pkg/identity/gitlabcom/issuer.go
@@ -1,0 +1,38 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabcom
+
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/pkg/identity"
+	"github.com/sigstore/fulcio/pkg/identity/base"
+)
+
+type gitlabIssuer struct {
+	identity.Issuer
+}
+
+func Issuer(issuerURL string) identity.Issuer {
+	return &gitlabIssuer{base.Issuer(issuerURL)}
+}
+
+func (e *gitlabIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return JobPrincipalFromIDToken(ctx, idtoken)
+}

--- a/pkg/identity/gitlabcom/issuer_test.go
+++ b/pkg/identity/gitlabcom/issuer_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabcom
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+func TestIssuer(t *testing.T) {
+	ctx := context.Background()
+	url := "test-issuer-url"
+	issuer := Issuer(url)
+
+	// test the Match function
+	t.Run("match", func(t *testing.T) {
+		if matches := issuer.Match(ctx, url); !matches {
+			t.Fatal("expected url to match but it doesn't")
+		}
+		if matches := issuer.Match(ctx, "some-other-url"); matches {
+			t.Fatal("expected match to fail but it didn't")
+		}
+	})
+
+	t.Run("authenticate", func(t *testing.T) {
+		token := &oidc.IDToken{
+			Issuer:  "https://iss.example.com",
+			Subject: "repo:sigstore/fulcio:ref:refs/heads/main",
+		}
+		claims, err := json.Marshal(map[string]interface{}{
+			"namespace_id":       "1730270",
+			"namespace_path":     "cpanato",
+			"project_id":         "42831435",
+			"project_path":       "cpanato/testing-cosign",
+			"user_id":            "1430381",
+			"user_login":         "cpanato",
+			"user_email":         "cpanato@example.com",
+			"pipeline_id":        "757451528",
+			"pipeline_source":    "push",
+			"job_id":             "3659681386",
+			"sha":                "714a629c0b401fdce83e847fc9589983fc6f46bc",
+			"runner_id":          1,
+			"runner_environment": "gitlab-hosted",
+			"ref":                "main",
+			"ref_type":           "branch",
+			"ref_protected":      "true",
+			"jti":                "914910cc-09f6-4217-8091-a1d3231a37db",
+			"iss":                "https://gitlab.com",
+			"iat":                1674658264,
+			"nbf":                1674658259,
+			"exp":                1674661864,
+			"sub":                "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+			"aud":                "sigstore",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		withClaims(token, claims)
+
+		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+			return token, nil
+		}
+		principal, err := issuer.Authenticate(ctx, "token")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if principal.Name(ctx) != "repo:sigstore/fulcio:ref:refs/heads/main" {
+			t.Fatalf("got unexpected name %s", principal.Name(ctx))
+		}
+	})
+}

--- a/pkg/identity/gitlabcom/principal.go
+++ b/pkg/identity/gitlabcom/principal.go
@@ -1,0 +1,204 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabcom
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/certificate"
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+type jobPrincipal struct {
+	// Subject matches the 'sub' claim from the OIDC ID token this is what is
+	// signed as proof of possession for Buildkite job identities
+	subject string
+
+	// OIDC Issuer URL. Matches 'iss' claim from ID token. The real issuer URL is
+	// https://agent.buildkite.com/.well-known/openid-configuration
+	issuer string
+
+	// The URL of the GitLab instance. https://gitlab.com
+	url string
+
+	// Event that triggered this workflow run. E.g "push", "tag" etc
+	eventName string
+
+	// Pipeline ID
+	pipelineID string
+
+	// Repository building built
+	repository string
+
+	// ID to the source repo
+	repositoryID string
+
+	// Owner of the source repo (mutable)
+	repositoryOwner string
+
+	// ID of the source repo
+	repositoryOwnerID string
+
+	// job ID
+	jobID string
+
+	// Git ref being built
+	ref string
+
+	// Commit SHA being built
+	sha string
+
+	// ID of the runner
+	runnerID int64
+
+	// The type of runner used by the job. May be one of gitlab-hosted or self-hosted.
+	runnerEnvironment string
+}
+
+func JobPrincipalFromIDToken(_ context.Context, token *oidc.IDToken) (identity.Principal, error) {
+	var claims struct {
+		ProjectPath       string `json:"project_path"`
+		ProjectID         string `json:"project_id"`
+		PipelineSource    string `json:"pipeline_source"`
+		PipelineID        string `json:"pipeline_id"`
+		NamespacePath     string `json:"namespace_path"`
+		NamespaceID       string `json:"namespace_id"`
+		JobID             string `json:"job_id"`
+		Ref               string `json:"ref"`
+		RefType           string `json:"ref_type"`
+		Sha               string `json:"sha"`
+		RunnerEnvironment string `json:"runner_environment"`
+		RunnerID          int64  `json:"runner_id"`
+	}
+
+	if err := token.Claims(&claims); err != nil {
+		return nil, err
+	}
+
+	if claims.ProjectPath == "" {
+		return nil, errors.New("missing project_path claim in ID token")
+	}
+
+	if claims.PipelineSource == "" {
+		return nil, errors.New("missing pipeline_source claim in ID token")
+	}
+
+	if claims.PipelineID == "" {
+		return nil, errors.New("missing pipeline_id claim in ID token")
+	}
+
+	if claims.JobID == "" {
+		return nil, errors.New("missing job_id claim in ID token")
+	}
+
+	if claims.Ref == "" {
+		return nil, errors.New("missing ref claim in ID token")
+	}
+
+	if claims.RefType == "" {
+		return nil, errors.New("missing ref_type claim in ID token")
+	}
+
+	if claims.NamespacePath == "" {
+		return nil, errors.New("missing namespace_path claim in ID token")
+	}
+
+	if claims.NamespaceID == "" {
+		return nil, errors.New("missing namespace_id claim in ID token")
+	}
+
+	if claims.ProjectID == "" {
+		return nil, errors.New("missing project_id claim in ID token")
+	}
+
+	if claims.Sha == "" {
+		return nil, errors.New("missing sha claim in ID token")
+	}
+
+	if claims.RunnerEnvironment == "" {
+		return nil, errors.New("missing runner_environment claim in ID token")
+	}
+
+	if claims.RunnerID == 0 {
+		return nil, errors.New("missing runner_id claim in ID token")
+	}
+
+	var ref string
+	switch claims.RefType {
+	case "branch":
+		ref = "refs/heads/" + claims.Ref
+	case "tag":
+		ref = "refs/tags/" + claims.Ref
+	default:
+		return nil, fmt.Errorf("unexpected ref_type: %s", claims.RefType)
+	}
+
+	return &jobPrincipal{
+		subject:           token.Subject,
+		issuer:            token.Issuer,
+		url:               `https://gitlab.com/`,
+		eventName:         claims.PipelineSource,
+		pipelineID:        claims.PipelineID,
+		repository:        claims.ProjectPath,
+		ref:               ref,
+		repositoryID:      claims.ProjectID,
+		repositoryOwner:   claims.NamespacePath,
+		repositoryOwnerID: claims.NamespaceID,
+		jobID:             claims.JobID,
+		sha:               claims.Sha,
+		runnerID:          claims.RunnerID,
+		runnerEnvironment: claims.RunnerEnvironment,
+	}, nil
+}
+
+func (p jobPrincipal) Name(_ context.Context) string {
+	return p.subject
+}
+
+func (p jobPrincipal) Embed(_ context.Context, cert *x509.Certificate) error {
+	baseURL, err := url.Parse(p.url)
+	if err != nil {
+		return err
+	}
+
+	// Set workflow ref URL to SubjectAlternativeName on certificate
+	cert.URIs = []*url.URL{baseURL.JoinPath(p.repository, "@", p.ref)}
+
+	// Embed additional information into custom extensions
+	cert.ExtraExtensions, err = certificate.Extensions{
+		Issuer:                          p.issuer,
+		BuildSignerURI:                  baseURL.JoinPath(p.repository, "/-/jobs/", p.jobID).String(),
+		RunnerEnvironment:               p.runnerEnvironment,
+		SourceRepositoryURI:             baseURL.JoinPath(p.repository).String(),
+		SourceRepositoryDigest:          p.sha,
+		SourceRepositoryRef:             p.ref,
+		SourceRepositoryIdentifier:      p.repositoryID,
+		SourceRepositoryOwnerURI:        baseURL.JoinPath(p.repositoryOwner).String(),
+		SourceRepositoryOwnerIdentifier: p.repositoryOwnerID,
+		BuildConfigURI:                  baseURL.JoinPath(p.repository, "/-/jobs/", p.jobID).String(),
+		BuildTrigger:                    p.eventName,
+		RunInvocationURI:                baseURL.JoinPath(p.repository, "/-/pipelines/", p.pipelineID).String(),
+	}.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/identity/gitlabcom/principal_test.go
+++ b/pkg/identity/gitlabcom/principal_test.go
@@ -1,0 +1,282 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabcom
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+func TestJobPrincipalFromIDToken(t *testing.T) {
+	tests := map[string]struct {
+		Claims          map[string]interface{}
+		ExpectPrincipal jobPrincipal
+		WantErr         bool
+		ErrContains     string
+	}{
+		`Valid token authenticates with correct claims`: {
+			Claims: map[string]interface{}{
+				"aud":                "sigstore",
+				"exp":                0,
+				"iss":                "https://gitlab.com",
+				"sub":                "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+				"project_id":         "42831435",
+				"project_path":       "cpanato/testing-cosign",
+				"namespace_path":     "cpanato",
+				"namespace_id":       "1730270",
+				"pipeline_id":        "757451528",
+				"pipeline_source":    "push",
+				"job_id":             "3659681386",
+				"ref":                "main",
+				"ref_type":           "branch",
+				"sha":                "714a629c0b401fdce83e847fc9589983fc6f46bc",
+				"runner_id":          1,
+				"runner_environment": "gitlab-hosted",
+			},
+			ExpectPrincipal: jobPrincipal{
+				issuer:            "https://gitlab.com",
+				subject:           "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+				url:               "https://gitlab.com/",
+				eventName:         "push",
+				pipelineID:        "757451528",
+				repository:        "cpanato/testing-cosign",
+				repositoryID:      "42831435",
+				repositoryOwner:   "cpanato",
+				repositoryOwnerID: "1730270",
+				jobID:             "3659681386",
+				ref:               "refs/heads/main",
+				runnerID:          1,
+				runnerEnvironment: "gitlab-hosted",
+				sha:               "714a629c0b401fdce83e847fc9589983fc6f46bc",
+			},
+			WantErr: false,
+		},
+		`Token missing pipeline_source claim should be rejected`: {
+			Claims: map[string]interface{}{
+				"aud":            "sigstore",
+				"exp":            0,
+				"iss":            "https://gitlab.com",
+				"sub":            "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+				"project_id":     "42831435",
+				"project_path":   "cpanato/testing-cosign",
+				"namespace_path": "cpanato",
+				"namespace_id":   "1730270",
+				"pipeline_id":    "757451528",
+				"job_id":         "3659681386",
+				"ref":            "main",
+				"ref_type":       "branch",
+			},
+			WantErr:     true,
+			ErrContains: "pipeline_source",
+		},
+		`Token missing project_path claim should be rejected`: {
+			Claims: map[string]interface{}{
+				"aud":             "sigstore",
+				"exp":             0,
+				"iss":             "https://gitlab.com",
+				"sub":             "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+				"project_id":      "42831435",
+				"pipeline_id":     "757451528",
+				"namespace_id":    "1730270",
+				"pipeline_source": "push",
+				"namespace_path":  "cpanato",
+				"job_id":          "3659681386",
+				"ref":             "main",
+				"ref_type":        "branch",
+			},
+			WantErr:     true,
+			ErrContains: "project_path",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			token := &oidc.IDToken{
+				Issuer:  test.Claims["iss"].(string),
+				Subject: test.Claims["sub"].(string),
+			}
+			claims, err := json.Marshal(test.Claims)
+			if err != nil {
+				t.Fatal(err)
+			}
+			withClaims(token, claims)
+
+			untyped, err := JobPrincipalFromIDToken(context.TODO(), token)
+			if err != nil {
+				if !test.WantErr {
+					t.Fatal("didn't expect error", err)
+				}
+				if !strings.Contains(err.Error(), test.ErrContains) {
+					t.Fatalf("expected error %s to contain %s", err, test.ErrContains)
+				}
+				return
+			}
+			if err == nil && test.WantErr {
+				t.Fatal("expected error but got none")
+			}
+
+			principal, ok := untyped.(*jobPrincipal)
+			if !ok {
+				t.Errorf("Got wrong principal type %v", untyped)
+			}
+			if *principal != test.ExpectPrincipal {
+				t.Errorf("got %v principal and expected %v", *principal, test.ExpectPrincipal)
+			}
+		})
+	}
+}
+
+// reflect hack because "claims" field is unexported by oidc IDToken
+// https://github.com/coreos/go-oidc/pull/329
+func withClaims(token *oidc.IDToken, data []byte) {
+	val := reflect.Indirect(reflect.ValueOf(token))
+	member := val.FieldByName("claims")
+	pointer := unsafe.Pointer(member.UnsafeAddr())
+	realPointer := (*[]byte)(pointer)
+	*realPointer = data
+}
+
+func TestName(t *testing.T) {
+	tests := map[string]struct {
+		Claims     map[string]interface{}
+		ExpectName string
+	}{
+		`Valid token authenticates with correct claims`: {
+			Claims: map[string]interface{}{
+				"aud":                "sigstore",
+				"exp":                0,
+				"iss":                "https://gitlab.com",
+				"sub":                "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+				"project_id":         "42831435",
+				"project_path":       "cpanato/testing-cosign",
+				"pipeline_id":        "757451528",
+				"pipeline_source":    "push",
+				"namespace_path":     "cpanato",
+				"namespace_id":       "1730270",
+				"job_id":             "3659681386",
+				"ref":                "main",
+				"ref_type":           "branch",
+				"sha":                "714a629c0b401fdce83e847fc9589983fc6f46bc",
+				"runner_id":          1,
+				"runner_environment": "gitlab-hosted",
+			},
+			ExpectName: "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			token := &oidc.IDToken{
+				Issuer:  test.Claims["iss"].(string),
+				Subject: test.Claims["sub"].(string),
+			}
+			claims, err := json.Marshal(test.Claims)
+			if err != nil {
+				t.Fatal(err)
+			}
+			withClaims(token, claims)
+
+			principal, err := JobPrincipalFromIDToken(context.TODO(), token)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotName := principal.Name(context.TODO())
+			if gotName != test.ExpectName {
+				t.Error("name should match sub claim")
+			}
+		})
+	}
+
+}
+
+func TestEmbed(t *testing.T) {
+	tests := map[string]struct {
+		Principal identity.Principal
+		WantErr   bool
+		WantFacts map[string]func(x509.Certificate) error
+	}{
+		`GitLab job challenge should have issue, subject and url embedded`: {
+			Principal: &jobPrincipal{
+				issuer:  "https://gitlab.com",
+				subject: "doesntmatter",
+				url:     `https://gitlab.com/honk/honk-repo/-/job/123456`,
+			},
+			WantErr: false,
+			WantFacts: map[string]func(x509.Certificate) error{
+				`Certifificate should have correct issuer`: factIssuerIs(`https://gitlab.com`),
+			},
+		},
+		`GitLab job principal with bad URL fails`: {
+			Principal: &jobPrincipal{
+				subject: "doesntmatter",
+				url:     "\nbadurl",
+			},
+			WantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var cert x509.Certificate
+			err := test.Principal.Embed(context.TODO(), &cert)
+			if err != nil {
+				if !test.WantErr {
+					t.Error(err)
+				}
+				return
+			} else if test.WantErr {
+				t.Error("expected error")
+			}
+			for factName, fact := range test.WantFacts {
+				t.Run(factName, func(t *testing.T) {
+					if err := fact(cert); err != nil {
+						t.Error(err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func factIssuerIs(issuer string) func(x509.Certificate) error {
+	return factExtensionIs(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}, issuer)
+}
+
+func factExtensionIs(oid asn1.ObjectIdentifier, value string) func(x509.Certificate) error {
+	return func(cert x509.Certificate) error {
+		for _, ext := range cert.ExtraExtensions {
+			if ext.Id.Equal(oid) {
+				if !bytes.Equal(ext.Value, []byte(value)) {
+					return fmt.Errorf("expected oid %v to be %s, but got %s", oid, value, ext.Value)
+				}
+				return nil
+			}
+		}
+		return errors.New("extension not set")
+	}
+}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -62,6 +62,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 	if request.Credentials != nil {
 		token = request.Credentials.GetOidcIdentityToken()
 	}
+
 	if token == "" {
 		if md, ok := metadata.FromIncomingContext(ctx); ok {
 			vals := md.Get(MetadataOIDCTokenKey)

--- a/pkg/server/issuer_pool.go
+++ b/pkg/server/issuer_pool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sigstore/fulcio/pkg/identity/buildkite"
 	"github.com/sigstore/fulcio/pkg/identity/email"
 	"github.com/sigstore/fulcio/pkg/identity/github"
+	"github.com/sigstore/fulcio/pkg/identity/gitlabcom"
 	"github.com/sigstore/fulcio/pkg/identity/kubernetes"
 	"github.com/sigstore/fulcio/pkg/identity/spiffe"
 	"github.com/sigstore/fulcio/pkg/identity/uri"
@@ -40,6 +41,7 @@ func NewIssuerPool(cfg *config.FulcioConfig) identity.IssuerPool {
 			ip = append(ip, iss)
 		}
 	}
+
 	return ip
 }
 
@@ -53,6 +55,8 @@ func getIssuer(meta string, i config.OIDCIssuer) identity.Issuer {
 		return email.Issuer(issuerURL)
 	case config.IssuerTypeGithubWorkflow:
 		return github.Issuer(issuerURL)
+	case config.IssuerTypeGitLabPipeline:
+		return gitlabcom.Issuer(issuerURL)
 	case config.IssuerTypeBuildkiteJob:
 		return buildkite.Issuer(issuerURL)
 	case config.IssuerTypeKubernetes:


### PR DESCRIPTION
#### Summary
- Add GitLab.com OIDC to Fulcio

Initial work to support gitlab.com, for self-hosted we will need to discuss how we want to deal with it.
similar work that was done in #890 

sample gitlab pipeline

```yaml
docker-build:
  # Use the official docker image.
  image: docker:latest
  stage: build
  variables:
    COSIGN_EXPERIMENTAL: "true"

  id_tokens:
    SIGSTORE_JWT:
      aud: "sigstore"
  before_script:
    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
    - apk add --update curl && rm -rf /var/cache/apk/*
    - curl -L https://github.com/sigstore/cosign/releases/download/v1.13.1/cosign-linux-amd64  -o cosign
    - chmod +x cosign
    - mv cosign /usr/bin
  script:
     - cosign sign --identity-token=${SIGSTORE_JWT} registry.gitlab.com/cpanato/testing-cosign:main
```

sample token payload

```json
{
  "namespace_id": "1730270",
  "namespace_path": "cpanato",
  "project_id": "42831435",
  "project_path": "cpanato/testing-cosign",
  "user_id": "1430381",
  "user_login": "cpanato",
  "user_email": "ctadeu@example.com",
  "pipeline_id": "757451528",
  "pipeline_source": "push",
  "job_id": "3659681386",
  "ref": "main",
  "ref_type": "branch",
  "ref_protected": "true",
  "jti": "914910cc-09f6-4217-8091-a1d3231a37db",
  "iss": "https://gitlab.com",
  "iat": 1674658264,
  "nbf": 1674658259,
  "exp": 1674661864,
  "sub": "project_path:cpanato/testing-cosign:ref_type:branch:ref:main",
  "aud": "sigstore"
}
```

Fixes https://github.com/sigstore/fulcio/issues/243