### PR TITLE
Begin implementing Issuer interface for email and github identities

### DIFF
--- a/pkg/identity/authorize.go
+++ b/pkg/identity/authorize.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
+)
+
+func extractIssuer(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("oidc: malformed jwt, expected 3 parts got %d", len(parts))
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("oidc: malformed jwt payload: %w", err)
+	}
+	var payload struct {
+		Issuer string `json:"iss"`
+	}
+
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", fmt.Errorf("oidc: failed to unmarshal claims: %w", err)
+	}
+	return payload.Issuer, nil
+}
+
+// We do this to bypass needing actual OIDC tokens for unit testing.
+var Authorize = actualAuthorize
+
+func actualAuthorize(ctx context.Context, token string) (*oidc.IDToken, error) {
+	issuer, err := extractIssuer(token)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier, ok := config.FromContext(ctx).GetVerifier(issuer)
+	if !ok {
+		return nil, fmt.Errorf("unsupported issuer: %s", issuer)
+	}
+	return verifier.Verify(ctx, token)
+}

--- a/pkg/identity/authorize.go
+++ b/pkg/identity/authorize.go
@@ -16,39 +16,17 @@ package identity
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/sigstore/fulcio/pkg/config"
 )
 
-func extractIssuer(token string) (string, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return "", fmt.Errorf("oidc: malformed jwt, expected 3 parts got %d", len(parts))
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("oidc: malformed jwt payload: %w", err)
-	}
-	var payload struct {
-		Issuer string `json:"iss"`
-	}
-
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", fmt.Errorf("oidc: failed to unmarshal claims: %w", err)
-	}
-	return payload.Issuer, nil
-}
-
 // We do this to bypass needing actual OIDC tokens for unit testing.
 var Authorize = actualAuthorize
 
 func actualAuthorize(ctx context.Context, token string) (*oidc.IDToken, error) {
-	issuer, err := extractIssuer(token)
+	issuer, err := extractIssuerURL(token)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/email/issuer.go
+++ b/pkg/identity/email/issuer.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email
+
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+type emailIssuer struct {
+	issuerURL string
+}
+
+func Issuer(issuerURL string) identity.Issuer {
+	return &emailIssuer{issuerURL: issuerURL}
+}
+
+func (e *emailIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return PrincipalFromIDToken(ctx, idtoken)
+}
+
+// Match checks if this issuer can authenticate tokens from a given issuer URL
+func (e *emailIssuer) Match(ctx context.Context, url string) bool {
+	return url == e.issuerURL
+}

--- a/pkg/identity/email/issuer_test.go
+++ b/pkg/identity/email/issuer_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+func TestIssuer(t *testing.T) {
+	ctx := context.Background()
+	url := "test-issuer-url"
+	issuer := Issuer(url)
+
+	// test the Match function
+	t.Run("match", func(t *testing.T) {
+		if matches := issuer.Match(ctx, url); !matches {
+			t.Fatal("expected url to match but it doesn't")
+		}
+		if matches := issuer.Match(ctx, "some-other-url"); matches {
+			t.Fatal("expected match to fail but it didn't")
+		}
+	})
+
+	t.Run("authenticate", func(t *testing.T) {
+		token := &oidc.IDToken{
+			Issuer:  "https://iss.example.com",
+			Subject: "subject",
+		}
+		claims, err := json.Marshal(map[string]interface{}{
+			"aud":            "sigstore",
+			"iss":            "https://iss.example.com",
+			"sub":            "doesntmatter",
+			"email":          "alice@example.com",
+			"email_verified": true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		withClaims(token, claims)
+
+		ctx := config.With(context.Background(), &config.FulcioConfig{
+			OIDCIssuers: map[string]config.OIDCIssuer{
+				"https://iss.example.com": {
+					IssuerURL: "https://iss.example.com",
+					Type:      config.IssuerTypeEmail,
+					ClientID:  "sigstore",
+				},
+			},
+		})
+
+		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+			return token, nil
+		}
+		principal, err := issuer.Authenticate(ctx, "token")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if principal.Name(ctx) != "alice@example.com" {
+			t.Fatalf("got unexpected name %s", principal.Name(ctx))
+		}
+	})
+}

--- a/pkg/identity/github/issuer.go
+++ b/pkg/identity/github/issuer.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+type githubIssuer struct {
+	issuerURL string
+}
+
+func Issuer(issuerURL string) identity.Issuer {
+	return &githubIssuer{issuerURL: issuerURL}
+}
+
+func (e *githubIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return WorkflowPrincipalFromIDToken(ctx, idtoken)
+}
+
+// Match checks if this issuer can authenticate tokens from a given issuer URL
+func (e *githubIssuer) Match(ctx context.Context, url string) bool {
+	return url == e.issuerURL
+}

--- a/pkg/identity/github/issuer_test.go
+++ b/pkg/identity/github/issuer_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/identity"
+)
+
+func TestIssuer(t *testing.T) {
+	ctx := context.Background()
+	url := "test-issuer-url"
+	issuer := Issuer(url)
+
+	// test the Match function
+	t.Run("match", func(t *testing.T) {
+		if matches := issuer.Match(ctx, url); !matches {
+			t.Fatal("expected url to match but it doesn't")
+		}
+		if matches := issuer.Match(ctx, "some-other-url"); matches {
+			t.Fatal("expected match to fail but it didn't")
+		}
+	})
+
+	t.Run("authenticate", func(t *testing.T) {
+		token := &oidc.IDToken{
+			Issuer:  "https://iss.example.com",
+			Subject: "repo:sigstore/fulcio:ref:refs/heads/main",
+		}
+		claims, err := json.Marshal(map[string]interface{}{
+			"aud":              "sigstore",
+			"event_name":       "push",
+			"exp":              0,
+			"iss":              "https://token.actions.githubusercontent.com",
+			"job_workflow_ref": "sigstore/fulcio/.github/workflows/foo.yaml@refs/heads/main",
+			"ref":              "refs/heads/main",
+			"repository":       "sigstore/fulcio",
+			"sha":              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"sub":              "repo:sigstore/fulcio:ref:refs/heads/main",
+			"workflow":         "foo",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		withClaims(token, claims)
+
+		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+			return token, nil
+		}
+		principal, err := issuer.Authenticate(ctx, "token")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if principal.Name(ctx) != "repo:sigstore/fulcio:ref:refs/heads/main" {
+			t.Fatalf("got unexpected name %s", principal.Name(ctx))
+		}
+	})
+}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -18,19 +18,17 @@ package server
 import (
 	"context"
 	"crypto"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/coreos/go-oidc/v3/oidc"
 	ctclient "github.com/google/certificate-transparency-go/client"
 	certauth "github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/challenges"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/ctl"
 	fulciogrpc "github.com/sigstore/fulcio/pkg/generated/protobuf"
+	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"google.golang.org/grpc/codes"
@@ -72,7 +70,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 	}
 
 	// Authenticate OIDC ID token by checking signature
-	idtoken, err := authorize(ctx, token)
+	idtoken, err := identity.Authorize(ctx, token)
 	if err != nil {
 		return nil, handleFulcioGRPCError(ctx, codes.Unauthenticated, err, invalidCredentials)
 	}
@@ -268,39 +266,4 @@ func (g *grpcCAServer) GetConfiguration(ctx context.Context, _ *fulciogrpc.GetCo
 	return &fulciogrpc.Configuration{
 		Issuers: cfg.ToIssuers(),
 	}, nil
-}
-
-func extractIssuer(token string) (string, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return "", fmt.Errorf("oidc: malformed jwt, expected 3 parts got %d", len(parts))
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("oidc: malformed jwt payload: %w", err)
-	}
-	var payload struct {
-		Issuer string `json:"iss"`
-	}
-
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", fmt.Errorf("oidc: failed to unmarshal claims: %w", err)
-	}
-	return payload.Issuer, nil
-}
-
-// We do this to bypass needing actual OIDC tokens for unit testing.
-var authorize = actualAuthorize
-
-func actualAuthorize(ctx context.Context, token string) (*oidc.IDToken, error) {
-	issuer, err := extractIssuer(token)
-	if err != nil {
-		return nil, err
-	}
-
-	verifier, ok := config.FromContext(ctx).GetVerifier(issuer)
-	if !ok {
-		return nil, fmt.Errorf("unsupported issuer: %s", issuer)
-	}
-	return verifier.Verify(ctx, token)
 }


### PR DESCRIPTION
I've been working on setting up Fulcio internally and ran into some blockers. I found this TODO in the code:

https://github.com/sigstore/fulcio/blob/13a2378a85f008e47bb445e79dedac1a49f605cf/pkg/server/grpc_server.go#L79-L81

This PR is the first step to completing it! This PR is 1/n in which I'll implement the [Issuer](https://github.com/sigstore/fulcio/blob/main/pkg/identity/issuer.go#L19) interface for each identity type, ultimately switching over to calling the interface functions for authentication. A lot of this work was already done by @nsmith5, I'm just finishing it up. 

The main benefit of this work is that it'll allow users to specify custom Issuers and Issuer Types if needed, making the upstream code more extensible.