### PR TITLE
Allow specifying ChallengeClaim for an Issuer in the Fulcio config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,7 +30,8 @@ var validCfg = `
 		"https://accounts.google.com": {
 			"IssuerURL": "https://accounts.google.com",
 			"ClientID": "foo",
-			"Type": "email"
+			"Type": "email",
+			"ChallengeClaim": "email"
 		}
 	},
 	"MetaIssuers": {
@@ -470,30 +471,34 @@ func Test_validateAllowedDomain(t *testing.T) {
 }
 
 func Test_issuerToChallengeClaim(t *testing.T) {
-	if claim := issuerToChallengeClaim(IssuerTypeEmail); claim != "email" {
+	if claim := issuerToChallengeClaim(IssuerTypeEmail, ""); claim != "email" {
 		t.Fatalf("expected email subject claim for email issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeSpiffe); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeSpiffe, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for SPIFFE issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeUsername); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeUsername, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for username issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeURI); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeURI, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for URI issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeBuildkiteJob); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeBuildkiteJob, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for Buildkite issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeGithubWorkflow); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeGithubWorkflow, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for GitHub issuer, got %s", claim)
 	}
-	if claim := issuerToChallengeClaim(IssuerTypeKubernetes); claim != "sub" {
+	if claim := issuerToChallengeClaim(IssuerTypeKubernetes, ""); claim != "sub" {
 		t.Fatalf("expected sub subject claim for K8S issuer, got %s", claim)
 	}
-	// unexpected issuer has empty claim
-	if claim := issuerToChallengeClaim("invalid"); claim != "" {
+	// unexpected issuer has empty claim and no claim was provided
+	if claim := issuerToChallengeClaim("invalid", ""); claim != "" {
 		t.Fatalf("expected no claim for invalid issuer, got %s", claim)
+	}
+	// custom issuer provides a claim
+	if claim := issuerToChallengeClaim("custom", "email"); claim != "email" {
+		t.Fatalf("expected email subject claim for custom issuer, got %s", claim)
 	}
 }
 


### PR DESCRIPTION
This will allow us to start setting up custom issuers! Right now this [switch](https://github.com/sigstore/fulcio/blob/main/pkg/config/config.go#L462) statement prevents users from doing that, but allowing the challenge claim to be specified in the Fulcio config should resolve that.