### PR TITLE
Don't add nil issuers to issuer pool

### DIFF
--- a/pkg/server/issuer_pool.go
+++ b/pkg/server/issuer_pool.go
@@ -29,10 +29,16 @@ import (
 func NewIssuerPool(cfg *config.FulcioConfig) identity.IssuerPool {
 	var ip identity.IssuerPool
 	for _, i := range cfg.OIDCIssuers {
-		ip = append(ip, getIssuer("", i))
+		iss := getIssuer("", i)
+		if iss != nil {
+			ip = append(ip, iss)
+		}
 	}
 	for meta, i := range cfg.MetaIssuers {
-		ip = append(ip, getIssuer(meta, i))
+		iss := getIssuer(meta, i)
+		if iss != nil {
+			ip = append(ip, iss)
+		}
 	}
 	return ip
 }

--- a/pkg/server/issuer_pool_test.go
+++ b/pkg/server/issuer_pool_test.go
@@ -39,6 +39,10 @@ func TestIssuerPool(t *testing.T) {
 				IssuerClaim: "$.federated_claims.connector_id",
 				Type:        config.IssuerTypeEmail,
 			},
+			"https://custom.issuer.type": {
+				IssuerURL: "https://custom.issuer.type",
+				Type:      "custom",
+			},
 		},
 	}
 	// Build the expected issuer pool


### PR DESCRIPTION
There's a chance the issuer can be nil if it's a custom issuer. If it's nil, don't add it to the issuer pool.