### PR TITLE
Change ParseDerString to Public Function

### DIFF
--- a/pkg/certificate/extensions.go
+++ b/pkg/certificate/extensions.go
@@ -344,59 +344,59 @@ func parseExtensions(ext []pkix.Extension) (Extensions, error) {
 			out.GithubWorkflowRef = string(e.Value)
 		// END: Deprecated
 		case e.Id.Equal(OIDIssuerV2):
-			if err := parseDERString(e.Value, &out.Issuer); err != nil {
+			if err := ParseDERString(e.Value, &out.Issuer); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDBuildSignerURI):
-			if err := parseDERString(e.Value, &out.BuildSignerURI); err != nil {
+			if err := ParseDERString(e.Value, &out.BuildSignerURI); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDBuildSignerDigest):
-			if err := parseDERString(e.Value, &out.BuildSignerDigest); err != nil {
+			if err := ParseDERString(e.Value, &out.BuildSignerDigest); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDRunnerEnvironment):
-			if err := parseDERString(e.Value, &out.RunnerEnvironment); err != nil {
+			if err := ParseDERString(e.Value, &out.RunnerEnvironment); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryURI):
-			if err := parseDERString(e.Value, &out.SourceRepositoryURI); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryURI); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryDigest):
-			if err := parseDERString(e.Value, &out.SourceRepositoryDigest); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryDigest); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryRef):
-			if err := parseDERString(e.Value, &out.SourceRepositoryRef); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryRef); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryIdentifier):
-			if err := parseDERString(e.Value, &out.SourceRepositoryIdentifier); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryIdentifier); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryOwnerURI):
-			if err := parseDERString(e.Value, &out.SourceRepositoryOwnerURI); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryOwnerURI); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDSourceRepositoryOwnerIdentifier):
-			if err := parseDERString(e.Value, &out.SourceRepositoryOwnerIdentifier); err != nil {
+			if err := ParseDERString(e.Value, &out.SourceRepositoryOwnerIdentifier); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDBuildConfigURI):
-			if err := parseDERString(e.Value, &out.BuildConfigURI); err != nil {
+			if err := ParseDERString(e.Value, &out.BuildConfigURI); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDBuildConfigDigest):
-			if err := parseDERString(e.Value, &out.BuildConfigDigest); err != nil {
+			if err := ParseDERString(e.Value, &out.BuildConfigDigest); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDBuildTrigger):
-			if err := parseDERString(e.Value, &out.BuildTrigger); err != nil {
+			if err := ParseDERString(e.Value, &out.BuildTrigger); err != nil {
 				return Extensions{}, err
 			}
 		case e.Id.Equal(OIDRunInvocationURI):
-			if err := parseDERString(e.Value, &out.RunInvocationURI); err != nil {
+			if err := ParseDERString(e.Value, &out.RunInvocationURI); err != nil {
 				return Extensions{}, err
 			}
 		}
@@ -407,9 +407,9 @@ func parseExtensions(ext []pkix.Extension) (Extensions, error) {
 	return out, nil
 }
 
-// parseDERString decodes a DER-encoded string and puts the value in parsedVal.
-// Rerturns an error if the unmarshalling fails or if there are trailing bytes in the encoding.
-func parseDERString(val []byte, parsedVal *string) error {
+// ParseDERString decodes a DER-encoded string and puts the value in parsedVal.
+// Returns an error if the unmarshalling fails or if there are trailing bytes in the encoding.
+func ParseDERString(val []byte, parsedVal *string) error {
 	rest, err := asn1.Unmarshal(val, parsedVal)
 	if err != nil {
 		return fmt.Errorf("unexpected error unmarshalling DER-encoded string: %v", err)

--- a/pkg/certificate/extensions_test.go
+++ b/pkg/certificate/extensions_test.go
@@ -175,3 +175,16 @@ func marshalDERString(t *testing.T, val string) []byte {
 	}
 	return derString
 }
+
+func TestParseDERString(t *testing.T) {
+	input := []byte{0x13, 0x0b, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64}
+	expected := "Hello World"
+	var actual string
+	err := ParseDERString(input, &actual)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if actual != expected {
+		t.Errorf("unexpected result: got %q, want %q", actual, expected)
+	}
+}


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Parsing the DER-encoded strings can be useful outside of the package so this switches the func to be public and adds a basic test.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Change the `parseDERString` to be a public function.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
