### PR TITLE
oid-info: Drop Build Signer Digest requirement from MUST -> SHOULD

### DIFF
--- a/docs/oid-info.md
+++ b/docs/oid-info.md
@@ -118,7 +118,7 @@ is formatted to the RFC 5280 specification as a DER-encoded string.
 
 ### 1.3.6.1.4.1.57264.1.9 | Build Signer URI
 
-Reference to specific build instructions that are responsible for signing. SHOULD be fully qualified. MAY be the same as Build Config URI. Build Signer URI is also included in the Subject Alternative Name.
+Reference to specific build instructions that are responsible for signing. SHOULD be fully qualified. MAY be the same as Build Config URI.
 
 For example a reusable workflow ref in GitHub Actions or a Circle CI Orb name/version. For example: `https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0`.
 

--- a/docs/oid-info.md
+++ b/docs/oid-info.md
@@ -18,12 +18,12 @@ Requirements:
 
 - MUST include `iss` claim for `Issuer` extension.
 - MUST include claim to support: `Build Signer URI` that identifies the specific build instructions that are responsible for signing.
-- MUST include claim to support: `Build Signer Digest` which is an immutable reference to a specific version of the build instructions that are responsible for signing.
 - MUST include claim to support: `Runner Environment` that differentiates between builds that took place in platform-hosted cloud infrastructure or customer-hosted infrastructure.
 
 Recommended:
 
 - SHOULD include `iss` that uniquely identifies ID tokens originating from the CI/CD system, e.g. not shared with OIDC OAuth 2.0 tokens for email/username logins.
+- SHOULD include claim to support: `Build Signer Digest` which is an immutable reference to a specific version of the build instructions that are responsible for signing.
 - SHOULD include claim to support: `Source Repository URI`
 - SHOULD include claim to support: `Source Repository Digest`
 - SHOULD include claim to support: `Source Repository Ref`


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

It was pointed out that CI providers may not be able to meet the Build Signer Digest requirement if they've been using server-assigned UUIDs to identify CI jobs rather than a user-verifiable digest.

Everyone seems to be in agreement that this is something CI providers SHOULD strive for so that users have a means of detecting misbehavior by the CI system, but this is not necessarily something we may want to gate acceptance on, since it would require work to implement and include.

As a result, dropping this down from MUST to SHOULD.

/cc @haydentherapper @kommendorkapten @feelepxyz @asraa @laurentsimon @aladh @marshall007 for any additional feedback

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Dropped `Build Signer Digest` OID requirement from `MUST` to `SHOULD`.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 

