### PR TITLE
fix cert.URIs

### DIFF
--- a/pkg/identity/gitlabcom/principal.go
+++ b/pkg/identity/gitlabcom/principal.go
@@ -179,7 +179,7 @@ func (p jobPrincipal) Embed(_ context.Context, cert *x509.Certificate) error {
 	}
 
 	// Set workflow ref URL to SubjectAlternativeName on certificate
-	cert.URIs = []*url.URL{baseURL.JoinPath(p.repository, "@", p.ref)}
+	cert.URIs = []*url.URL{baseURL.JoinPath(fmt.Sprintf("%s@%s", p.repository, p.ref))}
 
 	// Embed additional information into custom extensions
 	cert.ExtraExtensions, err = certificate.Extensions{

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -1051,7 +1051,7 @@ func TestAPIWithGitLab(t *testing.T) {
 		t.Fatalf("unexpected length of leaf certificate URIs, expected 1, got %d", len(leafCert.URIs))
 	}
 
-	gitLabURL := fmt.Sprintf("https://gitlab.com/%s/@/refs/heads/%s", claims.ProjectPath, claims.Ref)
+	gitLabURL := fmt.Sprintf("https://gitlab.com/%s@refs/heads/%s", claims.ProjectPath, claims.Ref)
 	gitLabURI, err := url.Parse(gitLabURL)
 	if err != nil {
 		t.Fatalf("failed to parse expected url")


### PR DESCRIPTION
#### Summary
- fix cert.URIs
It is generating `"https://gitlab.com/cpanato/testing-cosign/@/refs/heads/main"` and that should be `"https://gitlab.com/cpanato/testing-cosign@refs/heads/main"` for example


