### PR TITLE
Add support to specify hash function for KMS CA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ hack/tools/bin
 
 # vscode
 .vscode/
+
+# OS-generated files
+.DS_Store

--- a/pkg/ca/kmsca/kmsca.go
+++ b/pkg/ca/kmsca/kmsca.go
@@ -36,10 +36,10 @@ type kmsCA struct {
 	baseca.BaseCA
 }
 
-func NewKMSCA(ctx context.Context, kmsKey string, certs []*x509.Certificate, opts ...signature.RPCOption) (ca.CertificateAuthority, error) {
+func NewKMSCA(ctx context.Context, kmsKey string, certs []*x509.Certificate, hashFunc crypto.Hash, opts ...signature.RPCOption) (ca.CertificateAuthority, error) {
 	var ica kmsCA
 
-	kmsSigner, err := kms.Get(ctx, kmsKey, crypto.SHA256, opts...)
+	kmsSigner, err := kms.Get(ctx, kmsKey, hashFunc, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If using KMS providers other than GCP, the hash function is hardcoded to SHA256. (GCP provider looks up the keyversion and applies the correct hash function, other providers do not). This patch allows the user to configure the hash function with a CLI flag.