### PR TITLE
Adding Gitpod IDp

### DIFF
--- a/config/config.jsn
+++ b/config/config.jsn
@@ -20,6 +20,11 @@
       "IssuerURL": "https://token.actions.githubusercontent.com",
       "ClientID": "sigstore",
       "Type": "github-workflow"
+    },
+    "https://api.gitpod.io/idp": {
+      "IssuerURL": "https://api.gitpod.io/idp",
+      "ClientID": "sigstore",
+      "Type": "email"
     }
   }
 }

--- a/config/config.jsn
+++ b/config/config.jsn
@@ -5,6 +5,11 @@
       "ClientID": "sigstore",
       "Type": "email"
     },
+    "https://api.gitpod.io/idp": {
+      "IssuerURL": "https://api.gitpod.io/idp",
+      "ClientID": "sigstore",
+      "Type": "email"
+    },
     "https://oauth2.sigstore.dev/auth": {
       "IssuerURL": "https://oauth2.sigstore.dev/auth",
       "ClientID": "sigstore",
@@ -20,11 +25,6 @@
       "IssuerURL": "https://token.actions.githubusercontent.com",
       "ClientID": "sigstore",
       "Type": "github-workflow"
-    },
-    "https://api.gitpod.io/idp": {
-      "IssuerURL": "https://api.gitpod.io/idp",
-      "ClientID": "sigstore",
-      "Type": "email"
     }
   }
 }

--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -73,6 +73,11 @@ data:
               "IssuerURL": "https://token.actions.githubusercontent.com",
               "ClientID": "sigstore",
               "Type": "github-workflow"
+            },
+            "https://api.gitpod.io/idp": {
+              "IssuerURL": "https://api.gitpod.io/idp",
+              "ClientID": "sigstore",
+              "Type": "email"
             }
           },
           "MetaIssuers": {

--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -53,6 +53,11 @@ data:
               "ClientID": "sigstore",
               "Type": "gitlab-pipeline"
             },
+            "https://api.gitpod.io/idp": {
+              "IssuerURL": "https://api.gitpod.io/idp",
+              "ClientID": "sigstore",
+              "Type": "email"
+            },
             "https://gitlab.com": {
               "IssuerURL": "https://gitlab.com",
               "ClientID": "sigstore",
@@ -73,11 +78,6 @@ data:
               "IssuerURL": "https://token.actions.githubusercontent.com",
               "ClientID": "sigstore",
               "Type": "github-workflow"
-            },
-            "https://api.gitpod.io/idp": {
-              "IssuerURL": "https://api.gitpod.io/idp",
-              "ClientID": "sigstore",
-              "Type": "email"
             }
           },
           "MetaIssuers": {

--- a/federation/gitpod.io/config.yaml
+++ b/federation/gitpod.io/config.yaml
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 url: https://api.gitpod.io/idp
-contact: tbd
+contact: support@gitpod.io
 description: "Gitpod OIDC auth"
 type: "email"

--- a/federation/gitpod.io/config.yaml
+++ b/federation/gitpod.io/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: https://api.gitpod.io/idp
+contact: tbd
+description: "Gitpod OIDC auth"
+type: "email"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Closes #1176 

#### Summary

This MR adds Gitpod as a trusted identity provider using the email type to SaaS Fulcio. Gitpod is an remote IDE service aimed at providing workspace IDEs to users with all of the dependencies installed in seconds. Gitpod have been looking at Fulcio and gitsign as a means to achieve GPG signing for all commits made by users within a gitpod workspace. Adding Gitpod to SaaS Fulcio would allow them to pass through JWT tokens that identify a user, and get back a certificate automatically, without the user needing to do any additional authorisation.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
