### PR TITLE
gitlab: remove build config URI.

### DIFF
--- a/pkg/identity/gitlabcom/principal.go
+++ b/pkg/identity/gitlabcom/principal.go
@@ -192,7 +192,6 @@ func (p jobPrincipal) Embed(_ context.Context, cert *x509.Certificate) error {
 		SourceRepositoryIdentifier:      p.repositoryID,
 		SourceRepositoryOwnerURI:        baseURL.JoinPath(p.repositoryOwner).String(),
 		SourceRepositoryOwnerIdentifier: p.repositoryOwnerID,
-		BuildConfigURI:                  baseURL.JoinPath(p.repository, "/-/jobs/", p.jobID).String(),
 		BuildTrigger:                    p.eventName,
 		RunInvocationURI:                baseURL.JoinPath(p.repository, "/-/pipelines/", p.pipelineID).String(),
 	}.Render()

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -1061,6 +1061,7 @@ func TestAPIWithGitLab(t *testing.T) {
 	}
 	url := "https://gitlab.com/"
 	expectedExts := map[int]string{
+		9:  url + claims.ProjectPath + "/-/jobs/" + claims.JobID,
 		11: claims.RunnerEnvironment,
 		12: url + claims.ProjectPath,
 		13: claims.Sha,
@@ -1068,7 +1069,6 @@ func TestAPIWithGitLab(t *testing.T) {
 		15: claims.ProjectID,
 		16: url + claims.NamespacePath,
 		17: claims.NamespaceID,
-		18: url + claims.ProjectPath + "/-/jobs/" + claims.JobID,
 		20: claims.PipelineSource,
 		21: url + claims.ProjectPath + "/-/pipelines/" + claims.PipelineID,
 	}


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This was erroneously set to match the build signer URI. This will eventually be pipeline_ref when it is populated (dependent on https://gitlab.com/gitlab-org/gitlab/-/merge_requests/121597)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

BREAKING CHANGE: GitLab Build Config URI claim is temporarily removed. This was erroneously set to an incorrect value that did not match the documentation. This will repopulated once the correct value is available in upstream claims.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
