### PR TITLE
add HTTP and GRPC health check endpoints

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Cluster
         uses: chainguard-dev/actions/setup-kind@7d1eb557f464d97e5fe5177807a9226141eb9308 # main
         with:
-          k8s-version: v1.22.x
+          k8s-version: v1.24.x
           registry-authority: ${{ env.REGISTRY_NAME }}:${{ env.REGISTRY_PORT }}
 
       - name: Generate temporary CA files

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -47,10 +47,10 @@ jobs:
         include:
         - issuer: "OIDC Issuer"
           issuer-config: |
-            "OIDCIssuers": {"https://kubernetes.default.svc.cluster.local": {"IssuerURL": "https://kubernetes.default.svc.cluster.local","ClientID": "sigstore","Type": "kubernetes"}}
+            "OIDCIssuers": {"https://kubernetes.default.svc": {"IssuerURL": "https://kubernetes.default.svc","ClientID": "sigstore","Type": "kubernetes"}}
         - issuer: "Meta Issuer"
           issuer-config: |
-            "MetaIssuers": {"https://kubernetes.*.svc.cluster.local": {"ClientID": "sigstore","Type": "kubernetes"}}
+            "MetaIssuers": {"https://kubernetes.*.svc": {"ClientID": "sigstore","Type": "kubernetes"}}
 
     env:
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
@@ -73,9 +73,9 @@ jobs:
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
 
       - name: Setup Cluster
-        uses: chainguard-dev/actions/setup-kind@7d1eb557f464d97e5fe5177807a9226141eb9308 # main
+        uses: chainguard-dev/actions/setup-kind@f5a6616ce43b6ffabeddb87480a13721fffb3588 # main
         with:
-          k8s-version: v1.24.x
+          k8s-version: 1.24.x
           registry-authority: ${{ env.REGISTRY_NAME }}:${{ env.REGISTRY_PORT }}
 
       - name: Generate temporary CA files

--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -47,10 +47,10 @@ jobs:
         include:
         - issuer: "OIDC Issuer"
           issuer-config: |
-            "OIDCIssuers": {"https://kubernetes.default.svc": {"IssuerURL": "https://kubernetes.default.svc","ClientID": "sigstore","Type": "kubernetes"}}
+            "OIDCIssuers": {"https://kubernetes.default.svc.cluster.local": {"IssuerURL": "https://kubernetes.default.svc.cluster.local","ClientID": "sigstore","Type": "kubernetes"}}
         - issuer: "Meta Issuer"
           issuer-config: |
-            "MetaIssuers": {"https://kubernetes.*.svc": {"ClientID": "sigstore","Type": "kubernetes"}}
+            "MetaIssuers": {"https://kubernetes.*.svc.cluster.local": {"ClientID": "sigstore","Type": "kubernetes"}}
 
     env:
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
@@ -121,6 +121,7 @@ jobs:
             server.yaml: |-
               host: 0.0.0.0
               port: 5555
+              grpc-port: 5554
               ca: fileca
               fileca-cert: /etc/fulcio-secret/cert.pem
               fileca-key: /etc/fulcio-secret/key.pem

--- a/cmd/app/http.go
+++ b/cmd/app/http.go
@@ -17,6 +17,7 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,7 +33,9 @@ import (
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/fulcio/pkg/server"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
@@ -48,10 +51,21 @@ func extractOIDCTokenFromAuthHeader(_ context.Context, req *http.Request) metada
 }
 
 func createHTTPServer(ctx context.Context, serverEndpoint string, grpcServer, legacyGRPCServer *grpcServer) httpServer {
-	mux := runtime.NewServeMux(runtime.WithMetadata(extractOIDCTokenFromAuthHeader),
-		runtime.WithForwardResponseOption(setResponseCodeModifier))
+	opts := []grpc.DialOption{}
+	if grpcServer.ExposesGRPCTLS() {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	cc, err := grpc.Dial(grpcServer.grpcServerEndpoint, opts...)
+	if err != nil {
+		log.Logger.Fatal(err)
+	}
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	mux := runtime.NewServeMux(runtime.WithMetadata(extractOIDCTokenFromAuthHeader),
+		runtime.WithForwardResponseOption(setResponseCodeModifier),
+		runtime.WithHealthzEndpoint(health.NewHealthClient(cc)))
+
 	if err := gw.RegisterCAHandlerFromEndpoint(ctx, mux, grpcServer.grpcServerEndpoint, opts); err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/cmd/app/http.go
+++ b/cmd/app/http.go
@@ -53,6 +53,7 @@ func extractOIDCTokenFromAuthHeader(_ context.Context, req *http.Request) metada
 func createHTTPServer(ctx context.Context, serverEndpoint string, grpcServer, legacyGRPCServer *grpcServer) httpServer {
 	opts := []grpc.DialOption{}
 	if grpcServer.ExposesGRPCTLS() {
+		/* #nosec G402 */ // InsecureSkipVerify is only used for the HTTP server to call the TLS-enabled grpc endpoint.
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -70,6 +70,10 @@ spec:
             path: /healthz
             port: 5555
           initialDelaySeconds: 5
+        readinessProbe:
+          grpc:
+            port: 5554
+          initialDelaySeconds: 5
         resources:
           requests:
             memory: "1G"

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -70,10 +70,6 @@ spec:
             path: /healthz
             port: 5555
           initialDelaySeconds: 5
-        readinessProbe:
-          grpc:
-            port: 5554
-          initialDelaySeconds: 5
         resources:
           requests:
             memory: "1G"

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -65,6 +65,11 @@ spec:
           readOnly: true
         - name: oidc-info
           mountPath: /var/run/fulcio
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 5555
+          initialDelaySeconds: 5
         resources:
           requests:
             memory: "1G"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ~/.config/gcloud:/root/.config/gcloud/:z # for GCP authentication
       - ./config/config.jsn:/etc/fulcio-config/config.json:z
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5555/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:5555/healthz"]
       interval: 10s
       timeout: 3s
       retries: 3
@@ -62,7 +62,7 @@ services:
     volumes:
       - ./config/dex:/etc/config/:ro
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888/auth/healthz"]
+      test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:8888/auth/healthz"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type grpcCAServer struct {
+type GRPCCAServer struct {
 	fulciogrpc.UnimplementedCAServer
 	health.HealthServer
 	ct *ctclient.LogClient
@@ -45,8 +45,8 @@ type grpcCAServer struct {
 	identity.IssuerPool
 }
 
-func NewGRPCCAServer(ct *ctclient.LogClient, ca certauth.CertificateAuthority, ip identity.IssuerPool) *grpcCAServer {
-	return &grpcCAServer{
+func NewGRPCCAServer(ct *ctclient.LogClient, ca certauth.CertificateAuthority, ip identity.IssuerPool) *GRPCCAServer {
+	return &GRPCCAServer{
 		ct:         ct,
 		ca:         ca,
 		IssuerPool: ip,
@@ -57,7 +57,7 @@ const (
 	MetadataOIDCTokenKey = "oidcidentitytoken"
 )
 
-func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fulciogrpc.CreateSigningCertificateRequest) (*fulciogrpc.SigningCertificate, error) {
+func (g *GRPCCAServer) CreateSigningCertificate(ctx context.Context, request *fulciogrpc.CreateSigningCertificateRequest) (*fulciogrpc.SigningCertificate, error) {
 	logger := log.ContextLogger(ctx)
 
 	// OIDC token either is passed in gRPC field or was extracted from HTTP headers
@@ -231,7 +231,7 @@ func (g *grpcCAServer) CreateSigningCertificate(ctx context.Context, request *fu
 	return result, nil
 }
 
-func (g *grpcCAServer) GetTrustBundle(ctx context.Context, _ *fulciogrpc.GetTrustBundleRequest) (*fulciogrpc.TrustBundle, error) {
+func (g *GRPCCAServer) GetTrustBundle(ctx context.Context, _ *fulciogrpc.GetTrustBundleRequest) (*fulciogrpc.TrustBundle, error) {
 	trustBundle, err := g.ca.TrustBundle(ctx)
 	if err != nil {
 		return nil, handleFulcioGRPCError(ctx, codes.Internal, err, retrieveTrustBundleCAError)
@@ -255,7 +255,7 @@ func (g *grpcCAServer) GetTrustBundle(ctx context.Context, _ *fulciogrpc.GetTrus
 	return resp, nil
 }
 
-func (g *grpcCAServer) GetConfiguration(ctx context.Context, _ *fulciogrpc.GetConfigurationRequest) (*fulciogrpc.Configuration, error) {
+func (g *GRPCCAServer) GetConfiguration(ctx context.Context, _ *fulciogrpc.GetConfigurationRequest) (*fulciogrpc.Configuration, error) {
 	cfg := config.FromContext(ctx)
 	if cfg == nil {
 		err := errors.New("configuration not loaded")
@@ -267,10 +267,10 @@ func (g *grpcCAServer) GetConfiguration(ctx context.Context, _ *fulciogrpc.GetCo
 	}, nil
 }
 
-func (g *grpcCAServer) Check(_ context.Context, _ *health.HealthCheckRequest) (*health.HealthCheckResponse, error) {
+func (g *GRPCCAServer) Check(_ context.Context, _ *health.HealthCheckRequest) (*health.HealthCheckResponse, error) {
 	return &health.HealthCheckResponse{Status: health.HealthCheckResponse_SERVING}, nil
 }
 
-func (g *grpcCAServer) Watch(_ *health.HealthCheckRequest, _ health.Health_WatchServer) error {
+func (g *GRPCCAServer) Watch(_ *health.HealthCheckRequest, _ health.Health_WatchServer) error {
 	return status.Error(codes.Unimplemented, "unimplemented")
 }


### PR DESCRIPTION
#### Summary
This adds both HTTP and gRPC health check endpoints to Fulcio.

HTTP: `/healthz` should return `HTTP 200 OK`
gRPC: implements [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md)

This also adds coverage for this via K8S local testing using readiness and liveness probes in cluster.

#### Release Note
* HTTP and gRPC health check endpoints are now exposed from Fulcio

#### Documentation

- [ ] update docs.sigstore.dev to denote this feature
