### PR TITLE
Expose SkipExpiryCheck OIDC Config Option in Verifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
+	gotest.tools v2.2.0+incompatible
 	sigs.k8s.io/release-utils v0.7.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
-	gotest.tools v2.2.0+incompatible
 	sigs.k8s.io/release-utils v0.7.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -863,6 +863,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -863,8 +863,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/identity/authorize.go
+++ b/pkg/identity/authorize.go
@@ -25,13 +25,13 @@ import (
 // We do this to bypass needing actual OIDC tokens for unit testing.
 var Authorize = actualAuthorize
 
-func actualAuthorize(ctx context.Context, token string) (*oidc.IDToken, error) {
+func actualAuthorize(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 	issuer, err := extractIssuerURL(token)
 	if err != nil {
 		return nil, err
 	}
 
-	verifier, ok := config.FromContext(ctx).GetVerifier(issuer)
+	verifier, ok := config.FromContext(ctx).GetVerifier(issuer, opts...)
 	if !ok {
 		return nil, fmt.Errorf("unsupported issuer: %s", issuer)
 	}

--- a/pkg/identity/base/issuer.go
+++ b/pkg/identity/base/issuer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -38,7 +39,7 @@ func Issuer(issuerURL string) identity.Issuer {
 }
 
 // This is unimplemented for the base issuer, and should be implemented unique to each issuer
-func (e *baseIssuer) Authenticate(_ context.Context, token string) (identity.Principal, error) { //nolint: revive
+func (e *baseIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) { //nolint: revive
 	return nil, fmt.Errorf("unimplemented")
 }
 

--- a/pkg/identity/buildkite/issuer.go
+++ b/pkg/identity/buildkite/issuer.go
@@ -17,6 +17,7 @@ package buildkite
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &buildkiteIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *buildkiteIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *buildkiteIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/buildkite/issuer_test.go
+++ b/pkg/identity/buildkite/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -56,7 +57,7 @@ func TestIssuer(t *testing.T) {
 		}
 		withClaims(token, claims)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/email/issuer.go
+++ b/pkg/identity/email/issuer.go
@@ -17,6 +17,7 @@ package email
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &emailIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *emailIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *emailIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/email/issuer_test.go
+++ b/pkg/identity/email/issuer_test.go
@@ -66,7 +66,7 @@ func TestIssuer(t *testing.T) {
 			},
 		})
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/github/issuer.go
+++ b/pkg/identity/github/issuer.go
@@ -16,7 +16,9 @@ package github
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,10 +31,10 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &githubIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *githubIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *githubIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("authorizing github issuer: %w", err)
 	}
 	return WorkflowPrincipalFromIDToken(ctx, idtoken)
 }

--- a/pkg/identity/github/issuer_test.go
+++ b/pkg/identity/github/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -69,7 +70,7 @@ func TestIssuer(t *testing.T) {
 		}
 		withClaims(token, claims)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/gitlabcom/issuer.go
+++ b/pkg/identity/gitlabcom/issuer.go
@@ -17,6 +17,7 @@ package gitlabcom
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &gitlabIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *gitlabIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *gitlabIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/gitlabcom/issuer_test.go
+++ b/pkg/identity/gitlabcom/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -74,7 +75,7 @@ func TestIssuer(t *testing.T) {
 		}
 		withClaims(token, claims)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/issuer.go
+++ b/pkg/identity/issuer.go
@@ -14,7 +14,11 @@
 
 package identity
 
-import "context"
+import (
+	"context"
+
+	"github.com/sigstore/fulcio/pkg/config"
+)
 
 type Issuer interface {
 	// Match checks if this issuer can authenticate tokens from a given issuer URL
@@ -22,5 +26,5 @@ type Issuer interface {
 
 	// Authenticate ID token and return Principal on success. The ID token's signature
 	// is verified in the call -- invalid signature must result in an error.
-	Authenticate(ctx context.Context, token string) (Principal, error)
+	Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (Principal, error)
 }

--- a/pkg/identity/issuerpool.go
+++ b/pkg/identity/issuerpool.go
@@ -20,11 +20,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/sigstore/fulcio/pkg/config"
 )
 
 type IssuerPool []Issuer
 
-func (p IssuerPool) Authenticate(ctx context.Context, token string) (Principal, error) {
+func (p IssuerPool) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (Principal, error) {
 	url, err := extractIssuerURL(token)
 	if err != nil {
 		return nil, err
@@ -32,7 +34,7 @@ func (p IssuerPool) Authenticate(ctx context.Context, token string) (Principal, 
 
 	for _, issuer := range p {
 		if issuer.Match(ctx, url) {
-			return issuer.Authenticate(ctx, token)
+			return issuer.Authenticate(ctx, token, opts...)
 		}
 	}
 	return nil, fmt.Errorf("failed to match issuer URL %s from token with any configured providers", url)

--- a/pkg/identity/issuerpool_test.go
+++ b/pkg/identity/issuerpool_test.go
@@ -19,6 +19,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"testing"
+
+	"github.com/sigstore/fulcio/pkg/config"
 )
 
 type testPrincipal struct {
@@ -42,7 +44,7 @@ func (i testIssuer) Match(ctx context.Context, url string) bool {
 	return i.match(ctx, url)
 }
 
-func (i testIssuer) Authenticate(ctx context.Context, token string) (Principal, error) {
+func (i testIssuer) Authenticate(ctx context.Context, token string, _ ...config.InsecureOIDCConfigOption) (Principal, error) {
 	return i.auth(ctx, token)
 }
 

--- a/pkg/identity/kubernetes/issuer.go
+++ b/pkg/identity/kubernetes/issuer.go
@@ -17,6 +17,7 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &kubernetesIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *kubernetesIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *kubernetesIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/kubernetes/issuer_test.go
+++ b/pkg/identity/kubernetes/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
 
@@ -64,7 +65,7 @@ func TestIssuer(t *testing.T) {
 		}
 		withClaims(token, claims)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/spiffe/issuer.go
+++ b/pkg/identity/spiffe/issuer.go
@@ -17,6 +17,7 @@ package spiffe
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &spiffeIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *spiffeIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *spiffeIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/spiffe/issuer_test.go
+++ b/pkg/identity/spiffe/issuer_test.go
@@ -56,7 +56,7 @@ func TestIssuer(t *testing.T) {
 		}
 		ctx := config.With(context.Background(), cfg)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/uri/issuer.go
+++ b/pkg/identity/uri/issuer.go
@@ -17,6 +17,7 @@ package uri
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &uriIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *uriIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *uriIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/uri/issuer_test.go
+++ b/pkg/identity/uri/issuer_test.go
@@ -56,7 +56,7 @@ func TestIssuer(t *testing.T) {
 		}
 		ctx := config.With(context.Background(), cfg)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")

--- a/pkg/identity/username/issuer.go
+++ b/pkg/identity/username/issuer.go
@@ -17,6 +17,7 @@ package username
 import (
 	"context"
 
+	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 	"github.com/sigstore/fulcio/pkg/identity/base"
 )
@@ -29,8 +30,8 @@ func Issuer(issuerURL string) identity.Issuer {
 	return &usernameIssuer{base.Issuer(issuerURL)}
 }
 
-func (e *usernameIssuer) Authenticate(ctx context.Context, token string) (identity.Principal, error) {
-	idtoken, err := identity.Authorize(ctx, token)
+func (e *usernameIssuer) Authenticate(ctx context.Context, token string, opts ...config.InsecureOIDCConfigOption) (identity.Principal, error) {
+	idtoken, err := identity.Authorize(ctx, token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/username/issuer_test.go
+++ b/pkg/identity/username/issuer_test.go
@@ -56,7 +56,7 @@ func TestIssuer(t *testing.T) {
 		}
 		ctx := config.With(context.Background(), cfg)
 
-		identity.Authorize = func(_ context.Context, _ string) (*oidc.IDToken, error) {
+		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {
 			return token, nil
 		}
 		principal, err := issuer.Authenticate(ctx, "token")


### PR DESCRIPTION
This PR exposes some oidc config options allowed by the go-oidc library that we use, specifically [SkipExpiryCheck](https://github.com/coreos/go-oidc/blob/b203e58c24394ddf5e816706a7645f01280245c7/oidc/verify.go#L96). 

It updates the LRU cache for verifiers to include both the verifier and the config in the cache, so that Verifier A with a normal config can be distinguished from Verifier A with a config with SkipExpiryCheck set