### PR TITLE
Support GitLab's build and release instances as OIDC providers

### DIFF
--- a/config/fulcio-config.yaml
+++ b/config/fulcio-config.yaml
@@ -38,6 +38,11 @@ data:
               "ClientID": "sigstore",
               "Type": "email"
             },
+            "https://dev.gitlab.org": {
+              "IssuerURL": "https://dev.gitlab.org",
+              "ClientID": "sigstore",
+              "Type": "gitlab-pipeline"
+            },
             "https://gitlab.archlinux.org": {
               "IssuerURL": "https://gitlab.archlinux.org",
               "ClientID": "sigstore",
@@ -53,6 +58,11 @@ data:
               "ClientID": "sigstore",
               "Type": "email",
               "IssuerClaim": "$.federated_claims.connector_id"
+            },
+            "https://ops.gitlab.net": {
+              "IssuerURL": "https://ops.gitlab.net",
+              "ClientID": "sigstore",
+              "Type": "gitlab-pipeline"
             },
             "https://token.actions.githubusercontent.com": {
               "IssuerURL": "https://token.actions.githubusercontent.com",

--- a/federation/dev.gitlab.org/config.yaml
+++ b/federation/dev.gitlab.org/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: https://dev.gitlab.org
+contact: distribution-be@gitlab.com
+description: "GitLab OIDC tokens for job identity"
+type: "gitlab-pipeline"

--- a/federation/ops.gitlab.net/config.yaml
+++ b/federation/ops.gitlab.net/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: https://ops.gitlab.net
+contact: distribution-be@gitlab.com
+description: "GitLab OIDC tokens for job identity"
+type: "gitlab-pipeline"


### PR DESCRIPTION
#### Summary

We at GitLab (https://about.gitlab.com) are looking at integrating cosign to our official build and release workflow and are very much interested in using the keyless signing flow for it. However, our builds and releases happen not at GitLab.com, but at two separate GitLab instances - dev.gitlab.org and ops.gitlab.net. This PR adds support for those instances as valid OIDC token providers so that keyless signing and verification can be done in pipelines running on those instances.

As the first step, we will be signing our cloud native Docker images using cosign, and are also thinking about signing other build artifacts in the future.

PS: I referred to https://github.com/sigstore/fulcio/pull/1214 for this PR.

#### Release Note

* Support GitLab's build and release instances as OIDC providers

#### Documentation