### PR TITLE
Disable CGO on release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,9 +2,10 @@ project_name: fulcio
 
 env:
   - GO111MODULE=on
-  - CGO_ENABLED=1
   - DOCKER_CLI_EXPERIMENTAL=enabled
   - COSIGN_YES=true
+# If you need support for the the "createca" command, you must enable CGO
+  - CGO_ENABLED=0
 
 # Prevents parallel builds from stepping on eachothers toes downloading modules
 before:

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,12 +1,11 @@
-defaultBaseImage: gcr.io/distroless/base-debian10
+defaultBaseImage: gcr.io/distroless/static-debian12
 builds:
 - main: .
   env:
-  - CGO_ENABLED=1
-# If you are deploying from M1, you can use this (uncomment below, and
-# comment out above), though it does remove the support for the "createca" command.
-# But at least you can deploy it from M1 using this.
-#  - CGO_ENABLED=0
+  - CGO_ENABLED=0
+# If you need support for the the "createca" command, you must enable
+# CGO and use a base image with gblic (base instead of static)
+#  - CGO_ENABLED=1
   flags:
   - -trimpath
   - -tags

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: gcr.io/distroless/static-debian12
+defaultBaseImage: gcr.io/distroless/static-debian12:nonroot
 builds:
 - main: .
   env:


### PR DESCRIPTION
Update to base-debian12

Open questions?
- [ ] Does fulcio still actually need cgo or libssl, could we just use `base-nossl...` instead?
- [ ] Could we actually just run in `non-root` mode?