### PR TITLE
docs: Add back descriptive content on cert issuing

### DIFF
--- a/docs/how-certificate-issuing-works.md
+++ b/docs/how-certificate-issuing-works.md
@@ -112,4 +112,6 @@ See [Certificate Transparency Log Information](ctlog.md) for more details.
 
 ## 7 | Return certificate to client
 
+Finally, the certificate and SCT are both returned to the client.
+
 ![Return certificate diagram](img/return-cert.png)


### PR DESCRIPTION
As part of doc enhancements in ae4c766f, the description in step 7 was removed. Although the final step is simple and the diagram and section header are clear, it is jarring for the final step to be inconsistent with the others by having no text body. It is moreover unfriendly to screen readers since there is no context for the diagram. This change adds the brief description back for the sake of readability.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Enhance the documentation readability by having a consistent flow from step to step.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a