### PR TITLE
Fix debug docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENTRYPOINT ["/usr/local/bin/fulcio-server", "serve"]
 
 # debug compile options & debugger
 FROM deploy as debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
 # overwrite server and include debugger
 COPY --from=builder /opt/app-root/src/server_debug /usr/local/bin/fulcio-server

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       target: "debug"
-    command: [
+    entrypoint: [
       "dlv",
       "exec",
       "--listen=:2345",
@@ -30,10 +30,13 @@ services:
       "/usr/local/bin/fulcio-server",
       "serve",
       "--host=0.0.0.0",
-      "--port=3000",
+      "--port=5555",
+      "--grpc-port=5554",
+      "--ca=ephemeralca",
       ]
     restart: always # keep the server running
     ports:
-      - "3000:3000"
+      - "5555:5555"
+      - "5554:5554"
       - "2345:2345"
-      - "2112:2112"
+      - "${FULCIO_METRICS_PORT:-2112}:2112"


### PR DESCRIPTION
- Update dlv version to be compatible with Go 1.21
- Add required flag --ca to fulcio command
- Switch from "command" to "entrypoint" to override the ENTRYPOINT in the Dockerfile
- Use ports consistent with the main docker-compose file to avoid conflicting with rekor
- Use metrics port environment variable which was missed in ca33c989

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->