### PR TITLE
Fix docker-compose service order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       start_period: 5s
     depends_on:
       - dex-idp
-      - ct_server
     read_only: true
   dex-idp:
     image: dexidp/dex:v2.30.0
@@ -73,6 +72,7 @@ services:
       dockerfile: Dockerfile.ctfe_init
     depends_on:
       - trillian-log-server
+      - fulcio-server
     volumes:
       - ctfeConfig:/etc/config/:rw
   ct_server:
@@ -87,9 +87,12 @@ services:
     ]
     restart: always # retry while ctfe_init is running
     depends_on:
-      - trillian-log-server
-      - trillian-log-signer
-      - ctfe_init
+      trillian-log-server:
+        condition: service_started
+      trillian-log-signer:
+        condition: service_started
+      ctfe_init:
+        condition: service_completed_successfully
     ports:
       - "6962:6962"
   mysql:


### PR DESCRIPTION
Without this change, when Fulcio is run in docker-compose, signing an artifact may fail with the error "Error entering certificate in CTL". This happens if the docker-compose service have been run previously on the host and the ctfeConfig volume is populated from the last run, so it would generally only be seen in a developer environment. The error happens because the ctfe_init container starts too soon, and ct_server starts with Fulcio's ephemeral root CA from the last run, which is now the wrong CA. This change fixes the issue by ensuring ct_server only starts after ctfe_init has exited successfully, instead of just after it is started. This also means that Fulcio needs to be one of the first services to start so that it can make the ephemeral CA available to download.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
