### PR TITLE
Fix docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,8 @@ services:
       timeout: 3s
       retries: 3
       start_period: 10s
+    volumes:
+      - mysql:/var/lib/mysql
   trillian-log-server:
     image: gcr.io/trillian-opensource-ci/log_server
     command: [
@@ -141,3 +143,4 @@ services:
       - mysql
 volumes:
   ctfeConfig: {}
+  mysql: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "${FULCIO_METRICS_PORT:-2112}:2112"
     volumes:
       - ~/.config/gcloud:/root/.config/gcloud/:z # for GCP authentication
-      - ./config/config.jsn:/etc/fulcio-config/config.json:z
+      - ${FULCIO_CONFIG:-./config/config.jsn}:/etc/fulcio-config/config.json:z
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5555/healthz"]
       interval: 10s


### PR DESCRIPTION
## Make config path configurable

Add environment variable FULCIO_CONFIG to allow providing an alternate
configuration file rather than overwriting the default one. If a testing
environment overwrote the git-committed config/config.jsn, it would
pollute the repository checkout and be difficult to reuse on subsequent
test runs.

Needed by https://github.com/sigstore/cosign/pull/3499

## Add persistent volume for mysql

The ctfe_init container uses a persistent volume to store the tree head
ID among other things from previous runs. However, the mysql container
is not guaranteed to reuse the same data directory when it is destroyed
and recreated, so it may come up empty. When this happens, but the CT
log is configured for an existing tree, then signing objects will fail
with a Not Found error. This change adds a persistent volume to the
docker-compose file for mysql so that the database can live on and be
consistent with the CT log's configuration.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
