### PR TITLE
Added GitLab OIDC Provider documentation

### DIFF
--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -212,6 +212,34 @@ The token must include the following claims:
 
 All other required claims are extracted and included in custom OID fields, as documented in [OID Information](oid-info.md).
 
+### GitLab
+
+The token must include the following claims:
+
+```json
+{
+    "namespace_id": "72",
+    "namespace_path": "my-group",
+    "project_id": "20",
+    "project_path": "my-group/my-project",
+    "pipeline_id": "574",
+    "pipeline_source": "push",
+    "job_id": "302",
+    "ref": "main",
+    "ref_type": "branch",
+    "runner_id": 1,
+    "runner_environment": "gitlab-hosted",
+    "sha": "714a629c0b401fdce83e847fc9589983fc6f46bc",
+    "project_visibility": "public",
+    "ci_config_ref_uri": "gitlab.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main"
+}
+```
+
+`ci_config_ref_uri` is included as a SAN URI: `https://{ci_config_ref_uri}`
+
+All other required claims are extracted and included in custom OID fields, as documented in [OID Information](https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md#mapping-oidc-token-claims-to-fulcio-oids).
+
+
 ### SPIFFE
 
 The token must include the following claims:


### PR DESCRIPTION
Added GitLab OIDC provider to the documentation /docs/oidc.md file that was missing. 

The example was copied over from https://docs.sigstore.dev/certificate_authority/oidc-in-fulcio/ documentation.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
