### PR TITLE
Change parseExtension function to be public

### DIFF
--- a/pkg/certificate/extensions.go
+++ b/pkg/certificate/extensions.go
@@ -338,7 +338,7 @@ func (e Extensions) Render() ([]pkix.Extension, error) {
 	return exts, nil
 }
 
-func parseExtensions(ext []pkix.Extension) (Extensions, error) {
+func ParseExtensions(ext []pkix.Extension) (Extensions, error) {
 	out := Extensions{}
 
 	for _, e := range ext {

--- a/pkg/certificate/extensions_test.go
+++ b/pkg/certificate/extensions_test.go
@@ -162,7 +162,7 @@ func TestExtensions(t *testing.T) {
 				t.Errorf("Render: %s", diff)
 			}
 
-			parse, err := parseExtensions(render)
+			parse, err := ParseExtensions(render)
 			if err != nil {
 				t.Fatalf("ParseExtensions: err = %v", err)
 			}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Close #1583. The extensions_test.go has also been updated.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Changed the `pkg/certificate/parseExtensions` to be public allowing external Fulcio certificate consumers to parse all x509 extensions into the Extensions struct.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
None