### PR TITLE
Force sh scripts to checkout with lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 /pkg/generated/protobuf/** linguist-generated
+
+*.sh text eol=lf


### PR DESCRIPTION
On Windows the files copied to the docker container's work environment must have lf line endings to be properly executed.

Resolves #1605

#### Summary
On windows, if the dev cloning the repository has autocrlf set to true then sh files will have crlf line endings. When copied into the container they will keep this line ending and result in an error message: "/bin/sh: 1: /root/logid.sh: not found" in the ctfe_init container. 

#### Release Note
Forced sh file checkout to lf line endings for windows users. 

#### Documentation
No change. 
