### PR TITLE
Update /healthz probe to use localhost for gRPC readiness checks

### DIFF
--- a/cmd/app/http.go
+++ b/cmd/app/http.go
@@ -63,7 +63,8 @@ func createHTTPServer(ctx context.Context, serverEndpoint string, grpcServer, le
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
-	cc, err := grpc.NewClient(grpcServer.grpcServerEndpoint, opts...)
+	grpcHealthEndpoint := fmt.Sprintf("localhost:%s", viper.GetString("grpc-port"))
+	cc, err := grpc.NewClient(grpcHealthEndpoint, opts...)
 	if err != nil {
 		log.Logger.Fatal(err)
 	}


### PR DESCRIPTION
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This pull request resolves an issue with the `/healthz` probe failing in environments with a proxy enabled. The probe was using the `0.0.0.0` address for gRPC readiness checks, which could not be filtered by the `NO_PROXY` setting, causing readiness requests to be routed through the proxy and fail. This change updates the probe to use the `localhost` address, ensuring that these requests bypass the proxy and function correctly.

Closes #1704

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Updated `/healthz` probe to use localhost for gRPC readiness checks.

#### Documentation
No documentation updates are required for this change.
