### PR TITLE
bump builder to go1.22.4 / update golangci-lint and goreleaser config

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -33,9 +33,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.22.3-0@sha256:3217c1e30a7081d73500e620987947d1539cfebc99064ba0f7d5d6eef399475e \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.22.4-0@sha256:7769c9e4c92f1b598410566270a0aac39f6d0f68491e5bf0862df4ff0f11f06b \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.3-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.4-0"
         env:
           TUF_ROOT: /tmp
 
@@ -44,7 +44,7 @@ jobs:
     needs:
       - check-signature
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.22.3-0@sha256:3217c1e30a7081d73500e620987947d1539cfebc99064ba0f7d5d6eef399475e
+      image: ghcr.io/gythialy/golang-cross:v1.22.4-0@sha256:7769c9e4c92f1b598410566270a0aac39f6d0f68491e5bf0862df4ff0f11f06b
 
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -71,7 +71,7 @@ jobs:
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         timeout-minutes: 10
         with:
-          version: v1.57
+          version: v1.59
 
   oidc-config:
     name: oidc-config

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: fulcio
+version: 2
 
 env:
   - GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/fulcio
 
-go 1.21.9
+go 1.22.2
 
 require (
 	chainguard.dev/go-grpc-kit v0.17.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/fulcio
 
-go 1.22.2
+go 1.22.4
 
 require (
 	chainguard.dev/go-grpc-kit v0.17.5

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,13 +38,13 @@ steps:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.22.3-0@sha256:3217c1e30a7081d73500e620987947d1539cfebc99064ba0f7d5d6eef399475e'
+      - 'ghcr.io/gythialy/golang-cross:v1.22.4-0@sha256:7769c9e4c92f1b598410566270a0aac39f6d0f68491e5bf0862df4ff0f11f06b'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.3-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.4-0"
 
-  - name: ghcr.io/gythialy/golang-cross:v1.22.3-0@sha256:3217c1e30a7081d73500e620987947d1539cfebc99064ba0f7d5d6eef399475e
+  - name: ghcr.io/gythialy/golang-cross:v1.22.4-0@sha256:7769c9e4c92f1b598410566270a0aac39f6d0f68491e5bf0862df4ff0f11f06b
     entrypoint: /bin/sh
     dir: "go/src/sigstore/fulcio"
     env:
@@ -67,7 +67,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.22.3-0@sha256:3217c1e30a7081d73500e620987947d1539cfebc99064ba0f7d5d6eef399475e
+  - name: ghcr.io/gythialy/golang-cross:v1.22.4-0@sha256:7769c9e4c92f1b598410566270a0aac39f6d0f68491e5bf0862df4ff0f11f06b
     entrypoint: 'bash'
     dir: "go/src/sigstore/fulcio"
     env:

--- a/release/release.mk
+++ b/release/release.mk
@@ -10,7 +10,7 @@ release:
 # used when need to validate the goreleaser
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip=sign,publish --snapshot --clean
 
 
 ##################


### PR DESCRIPTION
#### Summary
- bump builder to go1.22.4 / update golangci-lint and goreleaser config