### PR TITLE
Surface the right `Name()` from our principal.

### DIFF
--- a/pkg/identity/chainguard/principal_test.go
+++ b/pkg/identity/chainguard/principal_test.go
@@ -60,6 +60,7 @@ func TestJobPrincipalFromIDToken(t *testing.T) {
 			ExpectPrincipal: workflowPrincipal{
 				issuer:  "https://issuer.enforce.dev",
 				subject: id.String(),
+				name:    id.String(),
 				actor: map[string]string{
 					"iss": "https://iss.example.com/",
 					"sub": fmt.Sprintf("catalog-syncer:%s", group.String()),
@@ -85,6 +86,34 @@ func TestJobPrincipalFromIDToken(t *testing.T) {
 			ExpectPrincipal: workflowPrincipal{
 				issuer:  "https://issuer.enforce.dev",
 				subject: group.String(),
+				name:    group.String(),
+				actor: map[string]string{
+					"iss": "https://auth.chainguard.dev/",
+					"sub": "google-oauth2|1234567890",
+					"aud": "fdsaldfkjhasldf",
+				},
+			},
+			WantErr: false,
+		},
+		`Human SSO token (with email)`: {
+			Claims: map[string]interface{}{
+				"iss":            "https://issuer.enforce.dev",
+				"sub":            group.String(),
+				"email":          "jane@doe.dev",
+				"email_verified": true,
+				// Actor claims track the identity that was used to assume the
+				// Chainguard identity.  In this case, it is the Catalog Syncer
+				// service principal.
+				"act": map[string]string{
+					"iss": "https://auth.chainguard.dev/",
+					"sub": "google-oauth2|1234567890",
+					"aud": "fdsaldfkjhasldf",
+				},
+			},
+			ExpectPrincipal: workflowPrincipal{
+				issuer:  "https://issuer.enforce.dev",
+				subject: group.String(),
+				name:    "jane@doe.dev",
 				actor: map[string]string{
 					"iss": "https://auth.chainguard.dev/",
 					"sub": "google-oauth2|1234567890",


### PR DESCRIPTION
#### Summary

The cosign logic for interacting with Fulcio treats identity tokens as *largely* opaque, and most of the logic for how issuers and subjects and whatnot is handled happens server-side.  However, for the "proof of possession" `cosign` has some logic (from `sigstore/sigstore`) that fumbles with `email` and `sub` claims in ways that have (until now) been compatible with Fulcio principals.

The Chainguard provider is the first provider that optionally includes an `email` claim, but we always want the subject we use to be our opaque identifier string (from `sub`).  This creates a tear in the fulcio/cosign continuum, and so we must surface what `cosign` is signing as `Name()` even though that isn't necessarily what we embed in the certificate.

The only correct way to implement `Name()` today is to match what this function does, and current implementations happen to align, but unfortunately because of how this abstraction is formulated it is challenging to actually change how we confirm the proof of possession to use this directly in place of the principal itself.

Fixes: https://github.com/sigstore/cosign/issues/3777

#### Release Note

This corrects the Chainguard PoP verification flow for tokens that embed email claims (makes `Name()` consistent with `cosign`).

#### Documentation

N/A
