### PR TITLE
fix: removing surplus slash, making logs richer

### DIFF
--- a/config/identity/config.yaml
+++ b/config/identity/config.yaml
@@ -178,7 +178,7 @@ ci-issuer-metadata:
       # ref_type: The type of the ref
       # E.g. "branch", "tag"
       # ref: Git ref being built
-      source-repository-ref: refs/{{if eq .ref_type "branch"}}heads/{{ else }}tags/{{end}}/{{ .ref }}
+      source-repository-ref: refs/{{if eq .ref_type "branch"}}heads/{{ else }}tags/{{end}}{{ .ref }}
       # project_id: ID to the source repo
       source-repository-identifier: "project_id"
       # namespace_path: Owner of the source repo (mutable)

--- a/pkg/identity/ciprovider/issuer_test.go
+++ b/pkg/identity/ciprovider/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/sigstore/fulcio/pkg/certificate"
 	"github.com/sigstore/fulcio/pkg/config"
 	"github.com/sigstore/fulcio/pkg/identity"
 )
@@ -81,8 +82,16 @@ func TestIssuer(t *testing.T) {
 					ClientID:   "sigstore",
 				},
 			}
+		template := "{{.foobar}}"
+		ciissuerMetadata := make(map[string]config.IssuerMetadata)
+		ciissuerMetadata["github-workflow"] = config.IssuerMetadata{
+			ExtensionTemplates: certificate.Extensions{
+				BuildTrigger: template,
+			},
+		}
 		cfg := &config.FulcioConfig{
-			OIDCIssuers: OIDCIssuers,
+			OIDCIssuers:      OIDCIssuers,
+			CIIssuerMetadata: ciissuerMetadata,
 		}
 		ctx = config.With(ctx, cfg)
 		identity.Authorize = func(_ context.Context, _ string, _ ...config.InsecureOIDCConfigOption) (*oidc.IDToken, error) {

--- a/pkg/identity/ciprovider/principal.go
+++ b/pkg/identity/ciprovider/principal.go
@@ -120,7 +120,7 @@ func (principal ciPrincipal) Embed(_ context.Context, cert *x509.Certificate) er
 	if err != nil {
 		return err
 	}
-	if strings.Trim(principal.ClaimsMetadata.SubjectAlternativeNameTemplate, " ") == "" {
+	if strings.TrimSpace(principal.ClaimsMetadata.SubjectAlternativeNameTemplate) == "" {
 		return fmt.Errorf("SubjectAlternativeNameTemplate should not be empty. Issuer: %s", principal.Token.Issuer)
 	}
 	subjectAlternativeName, err := applyTemplateOrReplace(principal.ClaimsMetadata.SubjectAlternativeNameTemplate, claims, defaults, principal.Token.Issuer)
@@ -143,7 +143,7 @@ func (principal ciPrincipal) Embed(_ context.Context, cert *x509.Certificate) er
 		s := v.Field(i).String() // value of each field, e.g the template string
 		// We check the field name to avoid to apply the template for the Issuer
 		// Issuer field should always come from the token issuer
-		if strings.Trim(s, " ") == "" || vType.Field(i).Name == "Issuer" {
+		if strings.TrimSpace(s) == "" || vType.Field(i).Name == "Issuer" {
 			continue
 		}
 		extValue, err := applyTemplateOrReplace(s, claims, defaults, principal.Token.Issuer)

--- a/pkg/identity/ciprovider/principal_test.go
+++ b/pkg/identity/ciprovider/principal_test.go
@@ -313,7 +313,10 @@ func TestApplyTemplateOrReplace(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			res, err := applyTemplateOrReplace(test.Template, tokenClaims, issuerMetadata, "https://token.actions.githubusercontent.com")
+			res, err := applyTemplateOrReplace(test.Template, tokenClaims, issuerMetadata,
+				map[string]string{
+					"Issuer": "https://token.actions.githubusercontent.com",
+				})
 			if res != test.ExpectedResult {
 				t.Errorf("expected result don't matches: Expected %s, received: %s, error: %v",
 					test.ExpectedResult, res, err)

--- a/pkg/identity/ciprovider/principal_test.go
+++ b/pkg/identity/ciprovider/principal_test.go
@@ -180,17 +180,25 @@ func TestName(t *testing.T) {
 			}
 			withClaims(token, claims)
 			ctx := context.TODO()
+			template := "{{.foobar}}"
+			ciissuerMetadata := make(map[string]config.IssuerMetadata)
+			ciissuerMetadata["github-workflow"] = config.IssuerMetadata{
+				ExtensionTemplates: certificate.Extensions{
+					BuildTrigger: template,
+				},
+			}
 			OIDCIssuers :=
 				map[string]config.OIDCIssuer{
 					token.Issuer: {
 						IssuerURL:  token.Issuer,
 						Type:       config.IssuerTypeCIProvider,
-						CIProvider: "ci-provider",
+						CIProvider: "github-workflow",
 						ClientID:   "sigstore",
 					},
 				}
 			cfg := &config.FulcioConfig{
-				OIDCIssuers: OIDCIssuers,
+				OIDCIssuers:      OIDCIssuers,
+				CIIssuerMetadata: ciissuerMetadata,
 			}
 			ctx = config.With(ctx, cfg)
 			principal, err := WorkflowPrincipalFromIDToken(ctx, token)
@@ -305,7 +313,7 @@ func TestApplyTemplateOrReplace(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			res, err := applyTemplateOrReplace(test.Template, tokenClaims, issuerMetadata)
+			res, err := applyTemplateOrReplace(test.Template, tokenClaims, issuerMetadata, "https://token.actions.githubusercontent.com")
 			if res != test.ExpectedResult {
 				t.Errorf("expected result don't matches: Expected %s, received: %s, error: %v",
 					test.ExpectedResult, res, err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
#### Summary
During the validations, we noticed that the the template for `source-repository-ref` for gitlab has a surplus slash.
We also noticed that the error with log `"value <> not present in either claims or defaults.` has spawned several times in production, but we wasn't able to detect the reason for it, then I decided to put at least the issuer that triggered the flow on the error log.
I also added a validation that the metadata should exist for ci-providers.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
cc @haydentherapper 
