### PR TITLE
set empty string as defaults for codefresh's optional fields

### DIFF
--- a/config/identity/config.yaml
+++ b/config/identity/config.yaml
@@ -203,6 +203,11 @@ ci-issuer-metadata:
       # for cases that the claimed data doesn't exist.
       # platform_url: Codefresh platform url
       platform_url: "https://g.codefresh.io"
+      scm_repo_url: ""
+      scm_ref: ""
+      runner_environment: ""
+      account_name: ""
+      pipeline_name: ""
     extension-templates:
       # workflow_id: The ID of the specific workflow authorized in the claim.
       # For example, 64f447c02199f903000gh20.

--- a/config/identity/config.yaml
+++ b/config/identity/config.yaml
@@ -206,8 +206,6 @@ ci-issuer-metadata:
       scm_repo_url: ""
       scm_ref: ""
       runner_environment: ""
-      account_name: ""
-      pipeline_name: ""
     extension-templates:
       # workflow_id: The ID of the specific workflow authorized in the claim.
       # For example, 64f447c02199f903000gh20.

--- a/pkg/identity/ciprovider/principal_test.go
+++ b/pkg/identity/ciprovider/principal_test.go
@@ -247,6 +247,7 @@ func TestApplyTemplateOrReplace(t *testing.T) {
 		"url":         "https://github.com",
 		"claim_foo":   "default",
 		"default_foo": "default_bar",
+		"empty_value": "",
 	}
 
 	tests := map[string]struct {
@@ -307,6 +308,11 @@ func TestApplyTemplateOrReplace(t *testing.T) {
 		`Should prior claims over defaults when they has the same name`: {
 			Template:       "claim_foo",
 			ExpectedResult: "bar",
+			ExpectErr:      false,
+		},
+		`Should return empty string for empty default`: {
+			Template:       "{{ .empty_value }}/123",
+			ExpectedResult: "/123",
 			ExpectErr:      false,
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Closes #1770

It set empty string as default value for optional fields on codefresh workflow.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
