### PR TITLE
It creates a action for a nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,22 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs at midnight every day
+
+concurrency: nightly-release
+
+jobs:
+  nightly-release:
+    name: Nightly release
+    uses: sigstore/community/.github/workflows/reusable-release.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      release_tag: nightly-latest
+      key_ring: ${{ github.event.inputs.key_ring }}
+      key_name: ${{ github.event.inputs.key_name }}
+      workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-fulcio'
+      service_account: 'github-actions-fulcio@projectsigstore.iam.gserviceaccount.com'
+      repo: 'fulcio'


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
It implements a action for having a nightly release for Fulcio.
This is part of a project for having a continuous deployment of Fulcio for Public good instance staging.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
