### PR TITLE
Adding breaking change label to container

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -76,4 +77,4 @@ jobs:
       - name: container
         run: |
           echo "Formated Label: ${{ steps.labels.outputs.FORMATED_LABELS }}"
-          KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio FORMATED_LABEL=${{ steps.labels.outputs.FORMATED_LABELS }} make sign-keyless-ci
+          KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio FORMATED_LABEL=${{ steps.labels.outputs.FORMATED_LABELS }} RUN_NUMBER=${{ github.run_number }} make sign-keyless-ci

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -77,4 +77,4 @@ jobs:
       - name: container
         run: |
           echo "Formated Label: ${{ steps.labels.outputs.FORMATED_LABELS }}"
-          KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio FORMATED_LABEL=${{ steps.labels.outputs.FORMATED_LABELS }} RUN_NUMBER=${{ github.run_number }} make sign-keyless-ci
+          KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio FORMATED_LABEL=${{ steps.labels.outputs.FORMATED_LABELS }} make sign-keyless-ci

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -59,5 +59,21 @@ jobs:
       - name: creds
         run: gcloud auth configure-docker --quiet
 
+      - name: Formatted labels
+        id: labels
+        run: |
+          FORMATED_LABELS="--image-label commit-hash=$GITHUB_SHA"
+
+          BRANCH_NUMBER=$(gh pr list --state all --search "sha:$GITHUB_SHA" --label "breaking-change" | awk '{print $1}')
+          echo "Branch Number: $BRANCH_NUMBER" 
+
+          # Check if a pull request number was found
+          if [ -n "$BRANCH_NUMBER" ]; then
+            FORMATED_LABELS+=" --image-label breaking-change=true"
+          fi
+          echo "FORMATED_LABELS='$FORMATED_LABELS'" >> $GITHUB_OUTPUT
+
       - name: container
-        run: KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio make sign-keyless-ci
+        run: |
+          echo "Formated Label: ${{ steps.labels.outputs.FORMATED_LABELS }}"
+          KO_PREFIX=gcr.io/projectsigstore/fulcio/ci/fulcio FORMATED_LABEL=${{ steps.labels.outputs.FORMATED_LABELS }} make sign-keyless-ci

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Formatted labels
         id: labels
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           FORMATED_LABELS="--image-label commit-hash=$GITHUB_SHA"
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ GHCR_PREFIX ?= ghcr.io/sigstore
 FULCIO_YAML ?= fulcio-$(GIT_TAG).yaml
 
 # It should be blank for default builds
-FORMATED_LABEL =
+FORMATED_LABEL ?=
+
+RUN_NUMBER ?= "local"
+
+FULL_TAG := "0.$(shell date +%Y%m%d).$(RUN_NUMBER)+ref.$(GIT_HASH)"
 
 # Binaries
 PROTOC-GEN-GO := $(TOOLS_BIN_DIR)/protoc-gen-go
@@ -126,7 +130,7 @@ ko:
 	# fulcio
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve $(FORMATED_LABEL) --bare \
-		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) --tags $(FULL_TAG) \
 		--image-refs fulcioImagerefs --filename config/ > $(FULCIO_YAML)
 
 .PHONY: ko-local

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ GHCR_PREFIX ?= ghcr.io/sigstore
 
 FULCIO_YAML ?= fulcio-$(GIT_TAG).yaml
 
+# It should be blank for default builds
+FORMATED_LABEL =
+
 # Binaries
 PROTOC-GEN-GO := $(TOOLS_BIN_DIR)/protoc-gen-go
 PROTOC-GEN-GO-GRPC := $(TOOLS_BIN_DIR)/protoc-gen-go-grpc

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ $(PROTOC-API-LINTER): $(TOOLS_DIR)/go.mod
 ko:
 	# fulcio
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve --bare \
+	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve $(FORMATED_LABEL) --bare \
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		--image-refs fulcioImagerefs --filename config/ > $(FULCIO_YAML)
 

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ FULCIO_YAML ?= fulcio-$(GIT_TAG).yaml
 # It should be blank for default builds
 FORMATED_LABEL ?=
 
-RUN_NUMBER ?= "local"
+GITHUB_RUN_NUMBER ?= "local"
 
-FULL_TAG := "0.$(shell date +%Y%m%d).$(RUN_NUMBER)+ref.$(GIT_HASH)"
+FULL_TAG := "0.$(shell date +%Y%m%d).$(GITHUB_RUN_NUMBER)-ref.$(GIT_VERSION)"
 
 # Binaries
 PROTOC-GEN-GO := $(TOOLS_BIN_DIR)/protoc-gen-go


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
It checks and adds the `breaking-change` label to the container that is created by the `build-container` action.
It also adds a label with the `commit-hash` to the container.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Example of a build with this configuration:

![image](https://github.com/user-attachments/assets/89d67b95-8050-4ed5-a414-f9e8b9643bf3)

