### PR TITLE
Add signature algorithm to template during certificate creation

### DIFF
--- a/cmd/app/createca.go
+++ b/cmd/app/createca.go
@@ -19,6 +19,7 @@
 package app
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/log"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/spf13/cobra"
@@ -124,6 +126,11 @@ func runCreateCACmd(cmd *cobra.Command, args []string) { //nolint: revive
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true, MaxPathLen: 1,
+	}
+
+	rootCA.SignatureAlgorithm, err = ca.ToSignatureAlgorithm(privKey, crypto.SHA256)
+	if err != nil {
+		log.Logger.Fatal(err)
 	}
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, pubKey, privKey)

--- a/pkg/ca/baseca/baseca.go
+++ b/pkg/ca/baseca/baseca.go
@@ -57,6 +57,11 @@ func (bca *BaseCA) CreatePrecertificate(ctx context.Context, principal identity.
 		Value:    asn1.NullBytes,
 	})
 
+	cert.SignatureAlgorithm, err = ca.ToSignatureAlgorithm(privateKey, crypto.SHA256)
+	if err != nil {
+		return nil, err
+	}
+
 	finalCertBytes, err := x509.CreateCertificate(rand.Reader, cert, certChain[0], publicKey, privateKey)
 	if err != nil {
 		return nil, err
@@ -115,6 +120,12 @@ func (bca *BaseCA) IssueFinalCertificate(_ context.Context, precert *ca.CodeSign
 
 	cert := precert.PreCert
 	cert.ExtraExtensions = exts
+
+	cert.SignatureAlgorithm, err = ca.ToSignatureAlgorithm(precert.PrivateKey, crypto.SHA256)
+	if err != nil {
+		return nil, err
+	}
+
 	finalCertBytes, err := x509.CreateCertificate(rand.Reader, cert, precert.CertChain[0], precert.PreCert.PublicKey, precert.PrivateKey)
 	if err != nil {
 		return nil, err
@@ -130,6 +141,11 @@ func (bca *BaseCA) CreateCertificate(ctx context.Context, principal identity.Pri
 	}
 
 	certChain, privateKey := bca.GetSignerWithChain()
+
+	cert.SignatureAlgorithm, err = ca.ToSignatureAlgorithm(privateKey, crypto.SHA256)
+	if err != nil {
+		return nil, err
+	}
 
 	finalCertBytes, err := x509.CreateCertificate(rand.Reader, cert, certChain[0], publicKey, privateKey)
 	if err != nil {

--- a/pkg/ca/common_test.go
+++ b/pkg/ca/common_test.go
@@ -16,9 +16,12 @@ package ca
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"strings"
 	"testing"
@@ -135,5 +138,145 @@ func TestVerifyCertChain(t *testing.T) {
 	err = VerifyCertChain([]*x509.Certificate{}, subKey)
 	if err == nil || !strings.Contains(err.Error(), "certificate chain must contain at least one certificate") {
 		t.Fatalf("expected error verifying with empty chain: %v", err)
+	}
+}
+
+func TestToSignatureAlgorithm(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA key: %v", err)
+	}
+
+	_, ed25519Key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate Ed25519 key: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		signer  crypto.Signer
+		hash    crypto.Hash
+		want    x509.SignatureAlgorithm
+		wantErr bool
+	}{
+		{
+			name:    "RSA with SHA256",
+			signer:  rsaKey,
+			hash:    crypto.SHA256,
+			want:    x509.SHA256WithRSA,
+			wantErr: false,
+		},
+		{
+			name:    "RSA with SHA384",
+			signer:  rsaKey,
+			hash:    crypto.SHA384,
+			want:    x509.SHA384WithRSA,
+			wantErr: false,
+		},
+		{
+			name:    "RSA with SHA512",
+			signer:  rsaKey,
+			hash:    crypto.SHA512,
+			want:    x509.SHA512WithRSA,
+			wantErr: false,
+		},
+		{
+			name:    "RSA with SHA1",
+			signer:  rsaKey,
+			hash:    crypto.SHA1,
+			want:    x509.SHA1WithRSA,
+			wantErr: false,
+		},
+		{
+			name:    "RSA with MD5",
+			signer:  rsaKey,
+			hash:    crypto.MD5,
+			want:    x509.MD5WithRSA,
+			wantErr: false,
+		},
+		{
+			name:    "RSA with unsupported hash",
+			signer:  rsaKey,
+			hash:    crypto.MD4,
+			want:    x509.UnknownSignatureAlgorithm,
+			wantErr: true,
+		},
+
+		{
+			name:    "ECDSA with SHA256",
+			signer:  ecdsaKey,
+			hash:    crypto.SHA256,
+			want:    x509.ECDSAWithSHA256,
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA with SHA384",
+			signer:  ecdsaKey,
+			hash:    crypto.SHA384,
+			want:    x509.ECDSAWithSHA384,
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA with SHA512",
+			signer:  ecdsaKey,
+			hash:    crypto.SHA512,
+			want:    x509.ECDSAWithSHA512,
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA with SHA1",
+			signer:  ecdsaKey,
+			hash:    crypto.SHA1,
+			want:    x509.ECDSAWithSHA1,
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA with unsupported hash",
+			signer:  ecdsaKey,
+			hash:    crypto.MD5,
+			want:    x509.UnknownSignatureAlgorithm,
+			wantErr: true,
+		},
+
+		{
+			name:    "Ed25519 with any hash",
+			signer:  ed25519Key,
+			hash:    crypto.SHA256,
+			want:    x509.PureEd25519,
+			wantErr: false,
+		},
+		{
+			name:    "Ed25519 with different hash",
+			signer:  ed25519Key,
+			hash:    crypto.SHA512,
+			want:    x509.PureEd25519,
+			wantErr: false,
+		},
+
+		{
+			name:    "nil signer",
+			signer:  nil,
+			hash:    crypto.SHA256,
+			want:    x509.UnknownSignatureAlgorithm,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToSignatureAlgorithm(tt.signer, tt.hash)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToSignatureAlgorithm() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ToSignatureAlgorithm() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/ca/ephemeralca/ephemeral.go
+++ b/pkg/ca/ephemeralca/ephemeral.go
@@ -16,6 +16,7 @@
 package ephemeralca
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -59,6 +60,11 @@ func NewEphemeralCA() (*EphemeralCA, error) {
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true, MaxPathLen: 1,
+	}
+
+	rootCA.SignatureAlgorithm, err = ca.ToSignatureAlgorithm(signer, crypto.SHA256)
+	if err != nil {
+		return nil, err
 	}
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, signer.Public(), signer)

--- a/pkg/certmaker/certmaker_test.go
+++ b/pkg/certmaker/certmaker_test.go
@@ -19,10 +19,8 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -513,146 +511,6 @@ func TestWriteCertificateToFile(t *testing.T) {
 				block, _ := pem.Decode(data)
 				require.NotNil(t, block)
 				require.Equal(t, "CERTIFICATE", block.Type)
-			}
-		})
-	}
-}
-
-func TestToSignatureAlgorithm(t *testing.T) {
-	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("Failed to generate RSA key: %v", err)
-	}
-
-	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate ECDSA key: %v", err)
-	}
-
-	_, ed25519Key, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate Ed25519 key: %v", err)
-	}
-
-	tests := []struct {
-		name    string
-		signer  crypto.Signer
-		hash    crypto.Hash
-		want    x509.SignatureAlgorithm
-		wantErr bool
-	}{
-		{
-			name:    "RSA with SHA256",
-			signer:  rsaKey,
-			hash:    crypto.SHA256,
-			want:    x509.SHA256WithRSA,
-			wantErr: false,
-		},
-		{
-			name:    "RSA with SHA384",
-			signer:  rsaKey,
-			hash:    crypto.SHA384,
-			want:    x509.SHA384WithRSA,
-			wantErr: false,
-		},
-		{
-			name:    "RSA with SHA512",
-			signer:  rsaKey,
-			hash:    crypto.SHA512,
-			want:    x509.SHA512WithRSA,
-			wantErr: false,
-		},
-		{
-			name:    "RSA with SHA1",
-			signer:  rsaKey,
-			hash:    crypto.SHA1,
-			want:    x509.SHA1WithRSA,
-			wantErr: false,
-		},
-		{
-			name:    "RSA with MD5",
-			signer:  rsaKey,
-			hash:    crypto.MD5,
-			want:    x509.MD5WithRSA,
-			wantErr: false,
-		},
-		{
-			name:    "RSA with unsupported hash",
-			signer:  rsaKey,
-			hash:    crypto.MD4,
-			want:    x509.UnknownSignatureAlgorithm,
-			wantErr: true,
-		},
-
-		{
-			name:    "ECDSA with SHA256",
-			signer:  ecdsaKey,
-			hash:    crypto.SHA256,
-			want:    x509.ECDSAWithSHA256,
-			wantErr: false,
-		},
-		{
-			name:    "ECDSA with SHA384",
-			signer:  ecdsaKey,
-			hash:    crypto.SHA384,
-			want:    x509.ECDSAWithSHA384,
-			wantErr: false,
-		},
-		{
-			name:    "ECDSA with SHA512",
-			signer:  ecdsaKey,
-			hash:    crypto.SHA512,
-			want:    x509.ECDSAWithSHA512,
-			wantErr: false,
-		},
-		{
-			name:    "ECDSA with SHA1",
-			signer:  ecdsaKey,
-			hash:    crypto.SHA1,
-			want:    x509.ECDSAWithSHA1,
-			wantErr: false,
-		},
-		{
-			name:    "ECDSA with unsupported hash",
-			signer:  ecdsaKey,
-			hash:    crypto.MD5,
-			want:    x509.UnknownSignatureAlgorithm,
-			wantErr: true,
-		},
-
-		{
-			name:    "Ed25519 with any hash",
-			signer:  ed25519Key,
-			hash:    crypto.SHA256,
-			want:    x509.PureEd25519,
-			wantErr: false,
-		},
-		{
-			name:    "Ed25519 with different hash",
-			signer:  ed25519Key,
-			hash:    crypto.SHA512,
-			want:    x509.PureEd25519,
-			wantErr: false,
-		},
-
-		{
-			name:    "nil signer",
-			signer:  nil,
-			hash:    crypto.SHA256,
-			want:    x509.UnknownSignatureAlgorithm,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToSignatureAlgorithm(tt.signer, tt.hash)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ToSignatureAlgorithm() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("ToSignatureAlgorithm() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
 Added ToSignatureAlgorithm to support specifying non-default hash algorithms during certificate creation
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#1161
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
