### PR TITLE
feat: add Dockerfile.dex-idp

### DIFF
--- a/Dockerfile.dex-idp
+++ b/Dockerfile.dex-idp
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM dexidp/dex:v2.30.0
+FROM dexidp/dex:v2.30.0@sha256:63fc6ee14bcf1868ebfba90885aec76597e0f27bc8e89d1fd238b1f2ee3dea6e
 
 COPY ./config/dex /etc/config/

--- a/Dockerfile.dex-idp
+++ b/Dockerfile.dex-idp
@@ -1,0 +1,18 @@
+#
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM dexidp/dex:v2.30.0
+
+COPY ./config/dex /etc/config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
     restart: always # keep the server running
     ports:
       - "8888:8888"
-    volumes:
-      - ./config/dex:/etc/config/:ro
     healthcheck:
       test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:8888/auth/healthz"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,9 @@ services:
       - dex-idp
     read_only: true
   dex-idp:
-    image: dexidp/dex:v2.30.0
+    build:
+      context: .
+      dockerfile: Dockerfile.dex-idp
     user: root
     command: [
       "dex",


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds a new Dockerfile.dex-idp to use in the docker-compose.yml. This makes the dex-idp more portable to be used in alternate docker-compose from external directories. For example, I may use the service like

```
services:
  dex-idp:
    build:
      context: https://github.com/sigstore/fulcio.git#main
      dockerfile: Dockerfile.dex-idp
...
```

https://docs.docker.com/reference/compose-file/build/#attributes

From any directory on the user's system, `docker compose` will do a checkout of the fulcio repo, and build the image with that dockerfile and with that repo  directory as the "docker context". The new dockerfile's `COPY ./config/dex /etc/config/` will build the image with those repo files.

The contents of `./config/dex` are not needed by the other services, and don't need to in a docker "volume". A developer modifying those files, can rebuild and restart their local image with the new file contents.

## Testing

the dex-idp service starts as normal. Cosign's e2e-test.sh also succeeds.

```
 *  Executing task: docker logs --tail 1000 -f 100a22320d93d6ccc3786652896fde56e9c048e7ccb7ef8e2cecd18c01b2880a 

time="2025-03-12T19:31:28Z" level=info msg="config issuer: http://dex-idp:8888/auth"
time="2025-03-12T19:31:28Z" level=info msg="config storage: memory"
time="2025-03-12T19:31:28Z" level=info msg="config static client: Fulcio in Docker Compose"
time="2025-03-12T19:31:28Z" level=info msg="config connector: https://any.valid.url/"
time="2025-03-12T19:31:28Z" level=info msg="config response types accepted: [code]"
time="2025-03-12T19:31:28Z" level=info msg="config skipping approval screen"
time="2025-03-12T19:31:28Z" level=info msg="config signing keys expire after: 24h0m0s"
time="2025-03-12T19:31:28Z" level=info msg="config id tokens valid for: 1m0s"
time="2025-03-12T19:31:28Z" level=info msg="config auth requests valid for: 24h0m0s"
time="2025-03-12T19:31:28Z" level=info msg="config refresh tokens rotation enabled: true"
time="2025-03-12T19:31:28Z" level=info msg="keys expired, rotating"
time="2025-03-12T19:31:28Z" level=info msg="keys rotated, next rotation: 2025-03-13 19:31:28.401165711 +0000 UTC"
time="2025-03-12T19:31:28Z" level=info msg="listening (http) on 0.0.0.0:8888"
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Dockerfile: convert dex-idp to Dockerfile.dex-idp.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None
