### PR TITLE
Register `/healthz` endpoint when listening on duplex http/grpc port

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -67,6 +67,7 @@ import (
 	"goa.design/goa/v3/grpc/middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -441,6 +442,16 @@ func checkServeCmdConfigFile() error {
 	return nil
 }
 
+func duplexHealthz(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	cc, err := grpc.NewClient(endpoint, opts...)
+	if err != nil {
+		return err
+	}
+	registerHealthz := runtime.WithHealthzEndpoint(health.NewHealthClient(cc))
+	registerHealthz(mux)
+	return nil
+}
+
 func StartDuplexServer(ctx context.Context, cfg *config.FulcioConfig, ctClient *ctclient.LogClient, baseca certauth.CertificateAuthority, algorithmRegistry *signature.AlgorithmRegistryConfig, host string, port, metricsPort int, ip identity.IssuerPool) error {
 	logger, opts := log.SetupGRPCLogging()
 
@@ -482,6 +493,12 @@ func StartDuplexServer(ctx context.Context, cfg *config.FulcioConfig, ctClient *
 	grpcMetrics.EnableHandlingTimeHistogram()
 	reg.MustRegister(grpcMetrics, server.MetricLatency, server.RequestsCount)
 	grpc_prometheus.Register(d.Server)
+
+	// Healthz
+	health.RegisterHealthServer(d.Server, grpcCAServer)
+	if err := d.RegisterHandler(ctx, duplexHealthz); err != nil {
+		return fmt.Errorf("registering healthz endpoint: %w", err)
+	}
 
 	// Register prometheus handle.
 	d.RegisterListenAndServeMetrics(metricsPort, false)

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -442,7 +442,7 @@ func checkServeCmdConfigFile() error {
 	return nil
 }
 
-func duplexHealthz(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+func duplexHealthz(_ context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	cc, err := grpc.NewClient(endpoint, opts...)
 	if err != nil {
 		return err

--- a/cmd/app/serve_test.go
+++ b/cmd/app/serve_test.go
@@ -119,4 +119,15 @@ func TestDuplex(t *testing.T) {
 			t.Fatalf("didn't get expected metrics output: %s", string(contents))
 		}
 	})
+
+	t.Run("healthz", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/healthz", port)
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if code := resp.StatusCode; code != 200 {
+			t.Fatalf("/healthz returned status code %d, want 200", code)
+		}
+	})
 }


### PR DESCRIPTION
#### Summary
Registers the `/healthz` endpoint when listening on a duplex http/grpc port, just like the `http` port does when running in non-duplex mode.

The current helm charts use this endpoint for the liveness and readiness probes, so I'm assuming this should be exposed even when HTTP and gRPC are listening on the same port.

Fixes https://github.com/sigstore/fulcio/issues/2047

#### Release Note
* /healthz is now exposed when running the HTTP and gRPC servers on the same port.