### PR TITLE
Optional claims-based authorization for private deployments

### DIFF
--- a/cmd/app/serve_test.go
+++ b/cmd/app/serve_test.go
@@ -56,7 +56,7 @@ func TestDuplex(t *testing.T) {
 	}
 
 	go func() {
-		if err := StartDuplexServer(ctx, config.DefaultConfig, nil, ca, algorithmRegistry, "localhost", port, metricsPort, nil); err != nil {
+		if err := StartDuplexServer(ctx, config.DefaultConfig, nil, ca, algorithmRegistry, "localhost", port, metricsPort, nil, nil); err != nil {
 			log.Fatalf("error starting duplex server: %v", err)
 		}
 	}()

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,0 +1,245 @@
+# Authorization
+
+## Summary
+
+Fulcio supports optional claims-based authorization that can be configured to restrict certificate issuance based on OIDC token claims. Authorization runs after successful OIDC authentication and before certificate creation, allowing fine-grained access control based on token metadata.
+
+## Overview
+
+The authorization system evaluates configurable rules against OIDC token claims to determine if a certificate request should be approved. This enables scenarios such as:
+
+- Restricting certificate issuance to specific repositories or organizations
+- Allowing only certain CI/CD pipelines to obtain certificates
+- Implementing custom access control policies based on token claims
+- Supporting multi-tenant environments with isolated access
+
+Authorization is **optional** - Fulcio continues to work when no authorization rules are configured.
+
+## How authorization works
+
+```
+OIDC Token → Authentication → Authorization → Certificate Issuance
+```
+
+1. **Authentication**: OIDC token is validated (configured OIDC Issuers + valid signature)
+2. **Authorization**: Token claims are evaluated against configured rules
+3. **Certificate Issuance**: Certificate is created if authorization passes or if no authorization rules are defined for the OIDC Issuer
+
+If authorization fails, the request is rejected with HTTP 403 Forbidden.
+
+## Configuration
+
+Authorization rules are configured per OIDC issuer in the Fulcio configuration file:
+
+```yaml
+oidc-issuers:
+  https://token.actions.githubusercontent.com:
+    issuer-url: https://token.actions.githubusercontent.com
+    client-id: sigstore
+    type: github-workflow
+    authorization-rules:
+      - name: "Allow specific organization repositories"
+        logic: "AND"
+        conditions:
+          - field: "repository_owner"
+            pattern: "^myorg$"
+          - field: "repository"
+            pattern: "^myorg/(prod-app|staging-app)$"
+      - name: "Allow admin user for any repository"
+        logic: "AND"
+        conditions:
+          - field: "actor"
+            pattern: "^admin@myorg\\.com$"
+```
+
+### Rule structure
+
+- **name**: Descriptive name for the rule (used in logging)
+- **logic**: Either "AND" or "OR" to combine conditions
+- **conditions**: Array of field/pattern pairs to evaluate
+
+### Condition structure
+
+- **field**: OIDC token claim to evaluate (e.g., "repository", "sub", "email")
+- **pattern**: Regular expression pattern to match against the claim value
+
+### Evaluation logic
+
+- **AND logic**: ALL conditions must match for the rule to pass
+- **OR logic**: ANY condition can match for the rule to pass
+- **Rule evaluation**: If ANY rule passes, authorization succeeds
+- **No rules**: If no rules are configured, authorization is skipped
+
+## Common use cases
+
+### 1. Repository-based access control
+
+Restrict certificate issuance to specific GitHub repositories:
+
+```yaml
+authorization-rules:
+  - name: "Production repositories only"
+    logic: "AND"
+    conditions:
+      - field: "repository_owner"
+        pattern: "^myorg$"
+      - field: "repository"
+        pattern: "^myorg/(api|web|mobile)$"
+```
+
+### 2. Organization-wide access
+
+Allow any repository within an organization:
+
+```yaml
+authorization-rules:
+  - name: "Organization members"
+    logic: "AND"
+    conditions:
+      - field: "repository_owner"
+        pattern: "^myorg$"
+```
+
+### 3. User-based access control
+
+Allow specific users regardless of repository:
+
+```yaml
+authorization-rules:
+  - name: "Authorized maintainers"
+    logic: "OR"
+    conditions:
+      - field: "actor"
+        pattern: "^(alice|bob|charlie)$"
+```
+
+### 4. Environment-based access
+
+Restrict based on deployment environment:
+
+```yaml
+authorization-rules:
+  - name: "Production deployments"
+    logic: "AND"
+    conditions:
+      - field: "job_workflow_ref"
+        pattern: "^myorg/[a-zA-Z0-9._-]{1,100}/.github/workflows/production.yaml@refs/heads/main"
+      - field: "repository_owner"
+        pattern: "^myorg$"
+```
+
+### 5. Multiple rule example
+
+Combine different access patterns:
+
+```yaml
+authorization-rules:
+  - name: "Production repositories"
+    logic: "AND"
+    conditions:
+      - field: "repository_owner"
+        pattern: "^myorg$"
+      - field: "repository"
+        pattern: "^myorg/(api|web)$"
+  - name: "Admin override"
+    logic: "AND"
+    conditions:
+      - field: "actor"
+        pattern: "^myorg-admin-bot$"
+```
+
+## Security considerations
+
+### Defense in depth
+
+Authorization provides an additional security layer after OIDC authentication:
+
+- **Authentication**: Verifies the token is valid and from a trusted issuer
+- **Authorization**: Verifies the authenticated identity should have access
+- **Transparency**: All decisions are logged to the certificate transparency log
+
+### Regular expression safety
+
+- Patterns use Go's `regexp` package, which is safe from ReDoS attacks
+- Patterns are compiled once at startup for performance
+- It is recommended to use anchors (`^` and `$`) to prevent partial matches
+- Patterns should be tested thoroughly before deployment
+
+### Token claim validation
+
+- Claims are extracted from authenticated OIDC tokens only
+- Authorization cannot be bypassed by manipulating unauthenticated tokens
+- All claim values are treated as strings for pattern matching
+
+### Configuration validation and server startup
+
+Fulcio prioritizes security over availability when it comes to authorization configuration:
+
+- **Configuration validation**: All regex patterns and rule structures are validated at startup
+- **Fail-secure by design**: Any malformed authorization rules will prevent server startup
+
+This ensures that authorization policies are always correctly applied and prevents accidental security misconfigurations.
+
+### Logging and monitoring
+
+Authorization decisions are logged with structured logging:
+
+```
+DEBUG authorization/authorizer.go:130 Authorization passed: rule matched
+DEBUG authorization/authorizer.go:145 Authorization denied: no rules matched
+```
+
+Monitor these logs to detect:
+- Unexpected authorization failures
+- Potential security policy violations
+- Need for rule adjustments
+
+## Troubleshooting
+
+### Server fails to start with authorization configuration errors
+
+Fulcio uses a fail-secure approach. Any malformed authorization configuration will prevent server startup:
+
+1. **Invalid regex patterns**: Check server startup logs for regex compilation errors
+2. **Empty rule names**: Ensure all rules have descriptive names
+3. **Invalid logic operators**: Use only "AND" or "OR" (case-insensitive)
+4. **Missing conditions**: Each rule must have at least one condition
+
+### Authorization always fails
+
+1. Verify OIDC token contains expected claims
+2. Test regex patterns against actual claim values
+3. Ensure at least one rule matches your use case
+4. Check that field names match actual token claims
+4. Start with broad patterns and narrow down
+5. Test regex patterns separately before adding to configuration
+
+### Authorization always passes
+
+1. Verify rules are configured in the correct issuer section
+2. Check that field names match actual token claims
+3. Ensure regex patterns have proper anchors when relevant (`^` and `$`)
+5. Test regex patterns separately before adding to configuration
+
+## Integration with Helm charts
+
+When deploying Fulcio with Helm (see [sigstore/helm-charts](https://github.com/sigstore/helm-charts/tree/main/charts/fulcio)), authorization rules can be configured via values:
+
+```yaml
+fulcio:
+  config:
+    contents:
+      OIDCIssuers:
+        "https://token.actions.githubusercontent.com":
+          IssuerURL: "https://token.actions.githubusercontent.com"
+          ClientID: "sigstore"
+          Type: "github-workflow"
+          AuthorizationRules:
+            - Name: "Allow specific repositories"
+              Logic: "AND"
+              Conditions:
+                - Field: "repository_owner"
+                  Pattern: "^myorg$"
+                - Field: "repository"
+                  Pattern: "^myorg/allowed-repo$"
+```

--- a/docs/how-certificate-issuing-works.md
+++ b/docs/how-certificate-issuing-works.md
@@ -40,16 +40,29 @@ To authenticate the token Fulcio must:
 - Download the issuer's signing keys from the discovery endpoint
 - Verify the ID token signature
 
-## 3 | Verifying the challenge
+## 3 | Authorization (optional)
 
-Once the client has been authenticated, the next step is to verify the client
-is in possession of the private key of the public key they’ve submitted. To do
+After successful authentication, Fulcio can optionally perform claims-based authorization
+if authorization rules are configured for the OIDC issuer. This step evaluates the
+authenticated token's claims against configurable access control rules.
+
+Authorization follows these principles:
+- Invalid authorization configurations prevent server startup
+- If authorization rules are configured and none match the token claims, the request is rejected with HTTP 403 Forbidden
+- If no authorization rules are configured, this step is skipped entirely
+
+See [Authorization documentation](authorization.md) for detailed configuration and examples.
+
+## 4 | Verifying the challenge
+
+Once the client has been authenticated (and optionally authorized), the next step is to verify the client
+is in possession of the private key of the public key they've submitted. To do
 this, Fulcio verifies the signed challenge or CSR. For a signed challenge, this is
 a signature of the `sub` claim. The challenge and CSR are verified using the provided public key.
 
 ![Challenge verification diagram](img/verify-challenge.png)
 
-## 4 | Constructing a certificate
+## 5 | Constructing a certificate
 
 The client is now authenticated and has proved possession of the private key. Fulcio now
 issues a code signing certificate for the identity from the ID token.
@@ -65,7 +78,7 @@ At a high level, this consists of:
 - Setting various X.509 extensions depending on the metadata in
   the OIDC ID token claims (e.g GitHub Actions workflow information)
 
-## 5 | Signing the certificate
+## 6 | Signing the certificate
 
 The code signing certificate is now populated, but needs to be signed
 by the certificate authority. This will form a chain of trust from the issued
@@ -81,11 +94,11 @@ Fulcio supports several signing backends to sign certificates:
   [softHSM](https://www.opendnssec.org/softhsm/) and others
 - [Google CA Service](https://cloud.google.com/certificate-authority-service/docs): A GCP-hosted certificate authority
 - Files: An on-disk password-protected private key
-- Ephemeral (for testing): An in-memory key pair generated on start up 
+- Ephemeral (for testing): An in-memory key pair generated on start up
 
 See [Setting up a Fulcio instance](setup.md) for more details.
 
-## 6 | Certificate Transparency log inclusion
+## 7 | Certificate Transparency log inclusion
 
 As part of certificate issuance, the certificate will be appended to an immutable, append-only,
 cryptographically verifiable certificate transparency (CT) log, which allows for issuance to be
@@ -110,7 +123,7 @@ transparency log. Fulcio's CT Log only stores issued certificates, while Rekor s
 
 See [Certificate Transparency Log Information](ctlog.md) for more details.
 
-## 7 | Return certificate to client
+## 8 | Return certificate to client
 
 Finally, the certificate and SCT are both returned to the client.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -15,6 +15,52 @@ acting maliciously or a compromised OIDC identity provider.
 Combined with [Rekor's](https://github.com/sigstore/rekor) signature transparency, artifacts signed with
 compromised accounts can be identified.
 
+## Claims-based Authorization
+
+Fulcio supports optional claims-based authorization that provides an additional security layer
+beyond OIDC authentication. This enables fine-grained access control policies based on
+authenticated token claims.
+
+### Defense in depth
+
+The security model operates in layers:
+
+1. **Authentication**: Verifies OIDC token is valid and from trusted issuer
+2. **Authorization** (Optional): Verifies authenticated identity should have access
+
+### Authorization security benefits
+
+- **Principle of least privilege**: Restrict access to only required identities
+- **Policy enforcement**: Implement organizational security policies
+- **Audit trail**: Detailed logging of authorization decisions
+
+### Example of security scenarios
+
+**Without authorization**:
+- Any valid GitHub token can request certificates
+- Compromised repository has broad certificate access
+- Difficult to implement organizational policies
+
+**With authorization**:
+- Only specified repositories can request certificates
+- Compromise is limited to explicitly allowed resources
+- Clear policy enforcement and violation detection
+
+### Configuration security
+
+Fulcio prioritizes security over availability in authorization configuration and follows these principles:
+
+- **Early validation**: All rules and regex patterns are validated at startup
+- **Fail-secure by design**: Invalid authorization rules prevent server startup (malformed rules never fall back to allow-all behavior)
+- **Regular expressions are compiled once at startup** (no ReDoS risk)
+- **Rules are evaluated against authenticated claims only**
+- **Authorization cannot be bypassed through token manipulation**
+- **All decisions are logged for audit and monitoring**
+
+This approach ensures that authorization policies are always correctly applied and prevents security misconfigurations from going unnoticed.
+
+See [Authorization documentation](authorization.md) for detailed configuration.
+
 ## Revocation, Rotation and Expiry
 
 Fulcio is designed to avoid the need for revocation of certificates. The Sigstore

--- a/pkg/authorization/authorizer.go
+++ b/pkg/authorization/authorizer.go
@@ -1,0 +1,284 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sigstore/fulcio/pkg/config"
+	"github.com/sigstore/fulcio/pkg/log"
+	"go.uber.org/zap"
+)
+
+// IDTokenClaims represents a token that can provide claims
+type IDTokenClaims interface {
+	Claims(v interface{}) error
+}
+
+type Authorizer interface {
+	Authorize(ctx context.Context, token IDTokenClaims, issuerConfig config.OIDCIssuer) error
+}
+
+type DefaultAuthorizer struct {
+	compiledRules map[string][]compiledRule
+}
+
+type compiledRule struct {
+	name       string
+	logic      string
+	conditions []compiledCondition
+}
+
+type compiledCondition struct {
+	field string
+	regex *regexp.Regexp
+}
+
+func NewDefaultAuthorizer() *DefaultAuthorizer {
+	return &DefaultAuthorizer{
+		compiledRules: make(map[string][]compiledRule),
+	}
+}
+
+// CompileRules pre-compiles authorization rules for the given issuer configuration
+func (a *DefaultAuthorizer) CompileRules(issuerURL string, rules []config.AuthorizationRule) error {
+	if len(rules) == 0 {
+		// No rules defined: allow all (default behavior)
+		return nil
+	}
+
+	var compiledRuleSet []compiledRule
+	for _, rule := range rules {
+		if err := validateRule(rule); err != nil {
+			return fmt.Errorf("invalid rule '%s' for issuer '%s': %w", rule.Name, issuerURL, err)
+		}
+
+		var compiledConditions []compiledCondition
+		for _, condition := range rule.Conditions {
+			regex, err := regexp.Compile(condition.Pattern)
+			if err != nil {
+				return fmt.Errorf("invalid regex pattern '%s' in rule '%s' for issuer '%s': %w",
+					condition.Pattern, rule.Name, issuerURL, err)
+			}
+			compiledConditions = append(compiledConditions, compiledCondition{
+				field: condition.Field,
+				regex: regex,
+			})
+		}
+
+		compiledRuleSet = append(compiledRuleSet, compiledRule{
+			name:       rule.Name,
+			logic:      strings.ToUpper(rule.Logic),
+			conditions: compiledConditions,
+		})
+	}
+
+	a.compiledRules[issuerURL] = compiledRuleSet
+	return nil
+}
+
+// Authorize checks if the token claims satisfy the authorization rules for the issuer
+func (a *DefaultAuthorizer) Authorize(ctx context.Context, token IDTokenClaims, issuerConfig config.OIDCIssuer) error {
+	logger := log.ContextLogger(ctx)
+	issuerURL := issuerConfig.IssuerURL
+
+	// Get compiled rules for this issuer
+	rules, exists := a.compiledRules[issuerURL]
+	if !exists || len(rules) == 0 {
+		// No rules defined for this issuer - allow by default
+		logger.Debug("No authorization rules defined for issuer - allowing by default",
+			zap.String("issuer", issuerURL))
+		return nil
+	}
+
+	// Extract all claims from the token
+	var claims map[string]interface{}
+	if err := token.Claims(&claims); err != nil {
+		return fmt.Errorf("failed to extract claims from token: %w", err)
+	}
+
+	logger.Debug("Evaluating authorization rules",
+		zap.String("issuer", issuerURL),
+		zap.Int("rule_count", len(rules)),
+		zap.String("subject", fmt.Sprintf("%v", claims["sub"])))
+
+	// Evaluate rules (OR logic between rules - any rule passes = authorized)
+	for _, rule := range rules {
+		if a.evaluateRule(ctx, rule, claims) {
+			logger.Debug("Authorization passed: rule matched",
+				zap.String("rule_name", rule.name),
+				zap.String("issuer", issuerURL))
+			return nil
+		}
+	}
+
+	// No rules passed
+	errorMsg := fmt.Sprintf("Authorization failed: no rules matched for issuer %s",
+		issuerURL)
+
+	logger.Warn("Authorization denied",
+		zap.String("issuer", issuerURL),
+		zap.String("subject", fmt.Sprintf("%v", claims["sub"])))
+
+	return fmt.Errorf("%s", errorMsg)
+}
+
+func (a *DefaultAuthorizer) evaluateRule(ctx context.Context, rule compiledRule, claims map[string]interface{}) bool {
+	logger := log.ContextLogger(ctx)
+
+	if len(rule.conditions) == 0 {
+		return true // Empty rule passes
+	}
+
+	// If there's only one condition, evaluate it directly
+	if len(rule.conditions) == 1 {
+		result := a.evaluateCondition(rule.conditions[0], claims)
+
+		claimValue, _ := claims[rule.conditions[0].field].(string)
+		logger.Debug("Single condition evaluation",
+			zap.String("rule_name", rule.name),
+			zap.String("field", rule.conditions[0].field),
+			zap.String("pattern", rule.conditions[0].regex.String()),
+			zap.String("claim_value", claimValue),
+			zap.Bool("result", result))
+
+		return result
+	}
+
+	// Multiple conditions - evaluate all and apply logic
+	results := make([]bool, len(rule.conditions))
+
+	// Evaluate each condition
+	for i, condition := range rule.conditions {
+		results[i] = a.evaluateCondition(condition, claims)
+
+		claimValue, _ := claims[condition.field].(string)
+		logger.Debug("Condition evaluation",
+			zap.String("rule_name", rule.name),
+			zap.Int("condition_index", i+1),
+			zap.String("field", condition.field),
+			zap.String("pattern", condition.regex.String()),
+			zap.String("claim_value", claimValue),
+			zap.Bool("result", results[i]))
+	}
+
+	// Determine logic operator (default to AND if not specified)
+	logic := rule.logic
+	if logic == "" {
+		logic = "AND"
+	}
+
+	// Apply logic (AND/OR)
+	switch logic {
+	case "AND":
+		for _, result := range results {
+			if !result {
+				logger.Debug("Rule failed (AND logic)",
+					zap.String("rule_name", rule.name))
+				return false
+			}
+		}
+		logger.Debug("Rule passed (AND logic)",
+			zap.String("rule_name", rule.name))
+		return true
+	case "OR":
+		for _, result := range results {
+			if result {
+				logger.Debug("Rule passed (OR logic)",
+					zap.String("rule_name", rule.name))
+				return true
+			}
+		}
+		logger.Debug("Rule failed (OR logic)",
+			zap.String("rule_name", rule.name))
+		return false
+	default:
+		// This should not happen due to validation, but handle gracefully
+		logger.Warn("Unknown logic operator, defaulting to AND",
+			zap.String("logic_operator", logic),
+			zap.String("rule_name", rule.name))
+		for _, result := range results {
+			if !result {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func (a *DefaultAuthorizer) evaluateCondition(condition compiledCondition, claims map[string]interface{}) bool {
+	claimValue, exists := claims[condition.field]
+	if !exists {
+		return false
+	}
+
+	var strValue string
+	switch v := claimValue.(type) {
+	case string:
+		strValue = v
+	case float64:
+		strValue = fmt.Sprintf("%.0f", v)
+	case bool:
+		strValue = fmt.Sprintf("%v", v)
+	default:
+		strValue = fmt.Sprintf("%v", v)
+	}
+
+	return condition.regex.MatchString(strValue)
+}
+
+func validateRule(rule config.AuthorizationRule) error {
+	if rule.Name == "" {
+		return fmt.Errorf("rule name cannot be empty")
+	}
+
+	if len(rule.Conditions) == 0 {
+		return fmt.Errorf("rule must have at least one condition")
+	}
+
+	if rule.Logic != "" {
+		logic := strings.ToUpper(rule.Logic)
+		if logic != "AND" && logic != "OR" {
+			return fmt.Errorf("invalid logic operator '%s'. Must be 'AND' or 'OR'", rule.Logic)
+		}
+	}
+
+	for i, condition := range rule.Conditions {
+		if err := validateCondition(condition); err != nil {
+			return fmt.Errorf("condition %d: %w", i+1, err)
+		}
+	}
+
+	return nil
+}
+
+func validateCondition(condition config.AuthorizationCondition) error {
+	if condition.Field == "" {
+		return fmt.Errorf("field cannot be empty")
+	}
+
+	if condition.Pattern == "" {
+		return fmt.Errorf("pattern cannot be empty")
+	}
+
+	if _, err := regexp.Compile(condition.Pattern); err != nil {
+		return fmt.Errorf("invalid regex pattern '%s': %w", condition.Pattern, err)
+	}
+
+	return nil
+}

--- a/pkg/authorization/authorizer_test.go
+++ b/pkg/authorization/authorizer_test.go
@@ -1,0 +1,631 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authorization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sigstore/fulcio/pkg/config"
+	"github.com/sigstore/fulcio/pkg/log"
+)
+
+// mockIDTokenClaims is a helper to create a mock token with claims
+type mockIDTokenClaims struct {
+	claims map[string]interface{}
+}
+
+func (m *mockIDTokenClaims) Claims(v interface{}) error {
+	// Copy claims to the provided interface (assuming it's a map)
+	if claimsMap, ok := v.(*map[string]interface{}); ok {
+		*claimsMap = m.claims
+	}
+	return nil
+}
+
+func newMockIDToken(claims map[string]interface{}) IDTokenClaims {
+	return &mockIDTokenClaims{claims: claims}
+}
+
+func TestDefaultAuthorizer_CompileRules(t *testing.T) {
+	authorizer := NewDefaultAuthorizer()
+
+	tests := []struct {
+		name        string
+		issuerURL   string
+		rules       []config.AuthorizationRule
+		expectError bool
+	}{
+		{
+			name:      "valid simple rule",
+			issuerURL: "https://token.actions.githubusercontent.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name: "Test rule",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "repository_owner", Pattern: "^example$"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:      "valid complex rule with AND logic",
+			issuerURL: "https://token.actions.githubusercontent.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name:  "Complex rule",
+					Logic: "AND",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "repository_owner", Pattern: "^example$"},
+						{Field: "workflow", Pattern: "^Release$"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:      "valid rule with OR logic",
+			issuerURL: "https://oidc.spire.example.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name:  "OR rule",
+					Logic: "OR",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "sub", Pattern: "^spiffe://example\\.com/prod/.*"},
+						{Field: "sub", Pattern: "^spiffe://example\\.com/staging/.*"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:      "invalid regex pattern",
+			issuerURL: "https://bad.issuer.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name: "Bad rule",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "test", Pattern: "[invalid"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:      "empty rule name",
+			issuerURL: "https://bad.issuer.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name: "",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "test", Pattern: "valid"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:      "no conditions",
+			issuerURL: "https://bad.issuer.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name:       "No conditions",
+					Conditions: []config.AuthorizationCondition{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:      "invalid logic operator",
+			issuerURL: "https://bad.issuer.com",
+			rules: []config.AuthorizationRule{
+				{
+					Name:  "Bad logic",
+					Logic: "XOR",
+					Conditions: []config.AuthorizationCondition{
+						{Field: "test", Pattern: "valid"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:        "empty rules array",
+			issuerURL:   "https://example.com",
+			rules:       []config.AuthorizationRule{},
+			expectError: false, // Empty rules should be allowed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := authorizer.CompileRules(tt.issuerURL, tt.rules)
+			if (err != nil) != tt.expectError {
+				t.Errorf("CompileRules() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestDefaultAuthorizer_Authorize(t *testing.T) {
+	ctx := context.Background()
+	// Setup logger for tests
+	log.ConfigureLogger("dev")
+
+	authorizer := NewDefaultAuthorizer()
+
+	// Compile test rules
+	githubRules := []config.AuthorizationRule{
+		{
+			Name: "Organization: example",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "repository_owner", Pattern: "^example$"},
+			},
+		},
+		{
+			Name:  "Production workflow",
+			Logic: "AND",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "repository_owner", Pattern: "^example$"},
+				{Field: "workflow", Pattern: "^Release$"},
+				{Field: "ref", Pattern: "^refs/heads/main$"},
+			},
+		},
+	}
+
+	spiffeRules := []config.AuthorizationRule{
+		{
+			Name: "SPIFFE Trust domain",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "sub", Pattern: "^spiffe://example\\.com/.*"},
+			},
+		},
+		{
+			Name:  "Production services",
+			Logic: "OR",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "sub", Pattern: "^spiffe://example\\.com/prod/.*"},
+				{Field: "sub", Pattern: "^spiffe://example\\.com/staging/.*"},
+			},
+		},
+	}
+
+	err := authorizer.CompileRules("https://token.actions.githubusercontent.com", githubRules)
+	if err != nil {
+		t.Fatalf("Failed to compile GitHub rules: %v", err)
+	}
+
+	err = authorizer.CompileRules("https://oidc.spire.example.com", spiffeRules)
+	if err != nil {
+		t.Fatalf("Failed to compile SPIFFE rules: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		issuerConfig config.OIDCIssuer
+		claims       map[string]interface{}
+		expectError  bool
+	}{
+		{
+			name: "GitHub - example organization passes",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://token.actions.githubusercontent.com",
+			},
+			claims: map[string]interface{}{
+				"iss":              "https://token.actions.githubusercontent.com",
+				"sub":              "repo:example/my-app:ref:refs/heads/main",
+				"repository_owner": "example",
+				"repository":       "example/my-app",
+				"workflow":         "CI",
+			},
+			expectError: false,
+		},
+		{
+			name: "GitHub - production workflow passes",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://token.actions.githubusercontent.com",
+			},
+			claims: map[string]interface{}{
+				"iss":              "https://token.actions.githubusercontent.com",
+				"sub":              "repo:example/my-app:ref:refs/heads/main",
+				"repository_owner": "example",
+				"repository":       "example/my-app",
+				"workflow":         "Release",
+				"ref":              "refs/heads/main",
+			},
+			expectError: false,
+		},
+		{
+			name: "GitHub - wrong organization fails",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://token.actions.githubusercontent.com",
+			},
+			claims: map[string]interface{}{
+				"iss":              "https://token.actions.githubusercontent.com",
+				"sub":              "repo:evil-org/my-app:ref:refs/heads/main",
+				"repository_owner": "evil-org",
+				"repository":       "evil-org/my-app",
+			},
+			expectError: true,
+		},
+		{
+			name: "GitHub - partial production workflow fails",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://token.actions.githubusercontent.com",
+			},
+			claims: map[string]interface{}{
+				"iss":              "https://token.actions.githubusercontent.com",
+				"sub":              "repo:other-org/my-app:ref:refs/heads/feature",
+				"repository_owner": "other-org", // Different org so first rule won't match
+				"workflow":         "Release",
+				"ref":              "refs/heads/feature", // Wrong branch for production rule
+			},
+			expectError: true,
+		},
+		{
+			name: "SPIFFE - trust domain passes",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://oidc.spire.example.com",
+			},
+			claims: map[string]interface{}{
+				"iss": "https://oidc.spire.example.com",
+				"sub": "spiffe://example.com/workload/api",
+				"aud": "fulcio",
+			},
+			expectError: false,
+		},
+		{
+			name: "SPIFFE - production service passes",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://oidc.spire.example.com",
+			},
+			claims: map[string]interface{}{
+				"iss": "https://oidc.spire.example.com",
+				"sub": "spiffe://example.com/prod/api-service",
+				"aud": "fulcio",
+			},
+			expectError: false,
+		},
+		{
+			name: "SPIFFE - wrong trust domain fails",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://oidc.spire.example.com",
+			},
+			claims: map[string]interface{}{
+				"iss": "https://oidc.spire.example.com",
+				"sub": "spiffe://evil.com/workload/api",
+				"aud": "fulcio",
+			},
+			expectError: true,
+		},
+		{
+			name: "No rules configured - should allow",
+			issuerConfig: config.OIDCIssuer{
+				IssuerURL: "https://no-rules.example.com",
+			},
+			claims: map[string]interface{}{
+				"iss": "https://no-rules.example.com",
+				"sub": "test-user",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := newMockIDToken(tt.claims)
+			err := authorizer.Authorize(ctx, token, tt.issuerConfig)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Authorize() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestDefaultAuthorizer_Authorize_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	log.ConfigureLogger("dev")
+
+	authorizer := NewDefaultAuthorizer()
+
+	// Test with numeric and boolean claims
+	rules := []config.AuthorizationRule{
+		{
+			Name: "Numeric field test",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "numeric_field", Pattern: "^123$"},
+			},
+		},
+		{
+			Name: "Boolean field test",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "boolean_field", Pattern: "^true$"},
+			},
+		},
+	}
+
+	err := authorizer.CompileRules("https://test.com", rules)
+	if err != nil {
+		t.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		claims      map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "numeric field matches",
+			claims: map[string]interface{}{
+				"numeric_field": 123.0, // JSON numbers are float64
+				"other_field":   "value",
+			},
+			expectError: false,
+		},
+		{
+			name: "boolean field matches",
+			claims: map[string]interface{}{
+				"boolean_field": true,
+				"other_field":   "value",
+			},
+			expectError: false,
+		},
+		{
+			name: "missing required field",
+			claims: map[string]interface{}{
+				"other_field": "value",
+			},
+			expectError: true,
+		},
+		{
+			name: "numeric field wrong value",
+			claims: map[string]interface{}{
+				"numeric_field": 456.0,
+				"other_field":   "value",
+			},
+			expectError: true,
+		},
+		{
+			name: "boolean field wrong value",
+			claims: map[string]interface{}{
+				"boolean_field": false,
+				"other_field":   "value",
+			},
+			expectError: true,
+		},
+	}
+
+	issuerConfig := config.OIDCIssuer{IssuerURL: "https://test.com"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := newMockIDToken(tt.claims)
+			err := authorizer.Authorize(ctx, token, issuerConfig)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Authorize() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateRule(t *testing.T) {
+	tests := []struct {
+		name        string
+		rule        config.AuthorizationRule
+		expectError bool
+	}{
+		{
+			name: "valid rule",
+			rule: config.AuthorizationRule{
+				Name: "Test rule",
+				Conditions: []config.AuthorizationCondition{
+					{Field: "test", Pattern: "valid"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty name",
+			rule: config.AuthorizationRule{
+				Name: "",
+				Conditions: []config.AuthorizationCondition{
+					{Field: "test", Pattern: "valid"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "no conditions",
+			rule: config.AuthorizationRule{
+				Name:       "Test rule",
+				Conditions: []config.AuthorizationCondition{},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid logic",
+			rule: config.AuthorizationRule{
+				Name:  "Test rule",
+				Logic: "INVALID",
+				Conditions: []config.AuthorizationCondition{
+					{Field: "test", Pattern: "valid"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid AND logic",
+			rule: config.AuthorizationRule{
+				Name:  "Test rule",
+				Logic: "and",
+				Conditions: []config.AuthorizationCondition{
+					{Field: "test", Pattern: "valid"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid OR logic",
+			rule: config.AuthorizationRule{
+				Name:  "Test rule",
+				Logic: "or",
+				Conditions: []config.AuthorizationCondition{
+					{Field: "test", Pattern: "valid"},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRule(tt.rule)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateRule() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		condition   config.AuthorizationCondition
+		expectError bool
+	}{
+		{
+			name: "valid condition",
+			condition: config.AuthorizationCondition{
+				Field:   "test",
+				Pattern: "valid",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty field",
+			condition: config.AuthorizationCondition{
+				Field:   "",
+				Pattern: "valid",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty pattern",
+			condition: config.AuthorizationCondition{
+				Field:   "test",
+				Pattern: "",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid regex",
+			condition: config.AuthorizationCondition{
+				Field:   "test",
+				Pattern: "[invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "complex valid regex",
+			condition: config.AuthorizationCondition{
+				Field:   "email",
+				Pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCondition(tt.condition)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateCondition() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+// Benchmark tests
+func BenchmarkAuthorize_SimpleRule(b *testing.B) {
+	ctx := context.Background()
+	log.ConfigureLogger("prod") // Reduce log noise in benchmarks
+
+	authorizer := NewDefaultAuthorizer()
+	rules := []config.AuthorizationRule{
+		{
+			Name: "Simple rule",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "repository_owner", Pattern: "^example$"},
+			},
+		},
+	}
+
+	err := authorizer.CompileRules("https://test.com", rules)
+	if err != nil {
+		b.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	issuerConfig := config.OIDCIssuer{IssuerURL: "https://test.com"}
+	claims := map[string]interface{}{
+		"repository_owner": "example",
+		"sub":              "test",
+	}
+	token := newMockIDToken(claims)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = authorizer.Authorize(ctx, token, issuerConfig)
+	}
+}
+
+func BenchmarkAuthorize_ComplexRule(b *testing.B) {
+	ctx := context.Background()
+	log.ConfigureLogger("prod")
+
+	authorizer := NewDefaultAuthorizer()
+	rules := []config.AuthorizationRule{
+		{
+			Name:  "Complex rule",
+			Logic: "AND",
+			Conditions: []config.AuthorizationCondition{
+				{Field: "repository_owner", Pattern: "^example$"},
+				{Field: "workflow", Pattern: "^Release$"},
+				{Field: "ref", Pattern: "^refs/heads/(main|release/.*)$"},
+				{Field: "actor", Pattern: "^[a-z0-9-]+$"},
+			},
+		},
+	}
+
+	err := authorizer.CompileRules("https://test.com", rules)
+	if err != nil {
+		b.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	issuerConfig := config.OIDCIssuer{IssuerURL: "https://test.com"}
+	claims := map[string]interface{}{
+		"repository_owner": "example",
+		"workflow":         "Release",
+		"ref":              "refs/heads/main",
+		"actor":            "release-bot",
+		"sub":              "test",
+	}
+	token := newMockIDToken(claims)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = authorizer.Authorize(ctx, token, issuerConfig)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,6 +122,27 @@ type OIDCIssuer struct {
 	// This is used to trust the TLS certificate signed by an internal CA when interacting
 	// with some OIDC providers, preventing x509 certificate verification failures.
 	CACert string `json:"CACert,omitempty" yaml:"ca-cert,omitempty"`
+
+	// AuthorizationRules contains optional claims-based authorization rules for this issuer
+	AuthorizationRules []AuthorizationRule `json:"AuthorizationRules,omitempty" yaml:"authorization-rules,omitempty"`
+}
+
+// AuthorizationCondition represents a single claim matching condition
+type AuthorizationCondition struct {
+	// Field is the JWT claim field to check
+	Field string `json:"field" yaml:"field"`
+	// Pattern is a regex pattern that the claim value must match
+	Pattern string `json:"pattern" yaml:"pattern"`
+}
+
+// AuthorizationRule represents a logical rule with multiple conditions
+type AuthorizationRule struct {
+	// Name is a human-readable description of this rule
+	Name string `json:"name" yaml:"name"`
+	// Logic specifies how to combine conditions: "AND" (default) or "OR"
+	Logic string `json:"logic,omitempty" yaml:"logic,omitempty"`
+	// Conditions are the individual claim checks that make up this rule
+	Conditions []AuthorizationCondition `json:"conditions" yaml:"conditions"`
 }
 
 func metaRegex(issuer string) (*regexp.Regexp, error) {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -99,7 +99,7 @@ func setupGRPCForTest(t *testing.T, cfg *config.FulcioConfig, ctl *ctclient.LogC
 	if err != nil {
 		t.Error(err)
 	}
-	protobuf.RegisterCAServer(s, NewGRPCCAServer(ctl, ca, algorithmRegistry, ip))
+	protobuf.RegisterCAServer(s, NewGRPCCAServer(ctl, ca, algorithmRegistry, ip, nil))
 	go func() {
 		if err := s.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			t.Errorf("Server exited with error: %v", err)


### PR DESCRIPTION
# Optional claims-based authorization for private deployments

## Summary

This pull request adds optional claims-based authorization functionality to Fulcio, enabling organizations with private deployments to implement fine-grained access control policies based on OIDC token claims. This feature addresses the need for basic authorization in private deployments to avoid generating certificates blindly for any valid OIDC token issued by a configured OIDC Issuer. The public Sigstore instance does not need this functionality as it serves the broader community.

Authorization operates as an additional security layer after successful OIDC authentication and before certificate issuance. When enabled, configurable regex-based rules evaluate authenticated token claims to determine if a certificate request should be approved.

Resolves: #1989

## Key features

- **Optional and backward compatible**: No impact on existing deployments (authorization is only active when rules are configured)
- **Claims-based access control**: Flexible rule system based on OIDC token claims
- **AND/OR logic support**: Rules can combine multiple conditions with configurable logic
- **Performance optimized**: Regex patterns are pre-compiled at startup for minimal runtime overhead
- **Auditability**: Comprehensive logging, audit trail available

## Configuration example

```yaml
oidc-issuers:
  https://token.actions.githubusercontent.com:
    issuer-url: https://token.actions.githubusercontent.com
    client-id: sigstore
    type: github-workflow
    authorization-rules:
      - name: "Production repositories of myorg"
        logic: "AND"
        conditions:
          - field: "repository_owner"
            pattern: "^myorg$"
          - field: "repository"
            pattern: "^myorg/(api|web|mobile)$"
      - name: "Admin override"
        logic: "AND"
        conditions:
          - field: "actor"
            pattern: "^myorg-admin-bot$"
```

## Implementation details

- **Authorization interface**: `pkg/authorization/authorizer.go` - Core authorization logic with configurable rule evaluation
- **Configuration extension**: `pkg/config/config.go` - Extends OIDC issuer configuration with authorization rules
- **Server integration**: `pkg/server/grpc_server.go` - Integrates authorization into certificate issuance flow
- **Startup setup**: `cmd/app/grpc.go`, `cmd/app/serve.go` - Rule compilation and authorizer initialization

## Documentation updates

- `docs/authorization.md`: Added feature documentation
- `docs/how-certificate-issuing-works.md`: Updated workflow documentation
- `docs/oidc.md`: Updated OIDC configuration guide
- `docs/security-model.md`: Updated security model with authorization

All necessary documentation updates are contained within the files modified in this repository, and no updates to official external documentation are required for this feature.

## Testing

- **Previous tests**: All existing tests continue to pass
- **Unit tests**: Added test coverage for authorization logic
- **Integration tested**: Verified with real GitHub OIDC tokens
- **Error scenarios**: Tested authorization failures, invalid configurations
- **Backward compatibility**: Verified existing functionality unchanged

## Backward compatibility

- **Backward compatible**: Existing deployments continue working without changes
- **Optional feature**: Feature is only active when authorization rules are configured
- **API unchanged**: Client integration remains identical

## Security considerations

- **No new attack vectors**: Authorization only restricts access, doesn't expand it
- **ReDoS protection**: Uses Go's safe regex implementation
- **Audit trail**: All decisions logged for security monitoring
- **Fail-secure by design**: Invalid authorization configuration prevents server startup (malformed rules never default to allow-all access)

## Release notes

```markdown
**Optional claims-based authorization for private deployments**

Organizations running private instances can now configure authorization rules to restrict certificate issuance based on OIDC token claims. This enables fine-grained access control policies without impacting existing deployments.

Authorization is completely optional and backward compatible: existing installations continue to work without any configuration changes.
```

## Remarks
Beyond the comprehensive unit test coverage included in this pull request, we have tested this authorization feature locally using a local Fulcio server with real GitHub OIDC tokens obtained from actual GitHub Actions workflows. The core authorization logic added here is also currently deployed and operational in a non-production environment, where it runs through Envoy filters as an interim solution while awaiting the merge of this pull request. We have not observed any particular performance impact or operational issues.

We want to emphasize our deliberate design choice regarding malformed authorization rules: the server will fail to start if authorization rules are configured but some are malformed. This fail-secure approach ensures that misconfigured rules never default to allow-all access. While we acknowledge that an alternative approach could allow the server to start and simply ignore malformed rules with warning messages, we strongly recommend against this behavior as it could lead to unintended security gaps where administrators might not notice that their intended restrictions are not being enforced.