### PR TITLE
server: Use warning log level for client errors

### DIFF
--- a/pkg/server/error.go
+++ b/pkg/server/error.go
@@ -42,6 +42,21 @@ const (
 )
 
 func handleFulcioGRPCError(ctx context.Context, code codes.Code, err error, message string, fields ...interface{}) error {
-	log.ContextLogger(ctx).Errorw(err.Error(), append([]interface{}{"code", code, "clientMessage", message, "error", err}, fields...)...)
+	// Use log level "warning" for codes that are likely client errors, see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+	switch code {
+	case codes.InvalidArgument,
+		codes.NotFound,
+		codes.AlreadyExists,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.FailedPrecondition,
+		codes.OutOfRange,
+		codes.Aborted,
+		codes.ResourceExhausted,
+		codes.Canceled:
+		log.ContextLogger(ctx).Warnw(err.Error(), append([]interface{}{"code", code, "clientMessage", message, "error", err}, fields...)...)
+	default:
+		log.ContextLogger(ctx).Errorw(err.Error(), append([]interface{}{"code", code, "clientMessage", message, "error", err}, fields...)...)
+	}
 	return status.Error(code, message)
 }


### PR DESCRIPTION
Decide the log level of errors based on the grpc code: client mistakes should not be logged at "error" level.

Fulcio itself currently uses only Internal and InvalidArgument, grpc framework does not use most of the codes listed either: this code still tries to categorize all valid codes in order to be future proof.

Fixes #908.

### test

this client call:
```
$ curl -X POST -d '{}' http://localhost:5555/api/v2/signingCert
{"code":3,"message":"There was an error processing the identity token","details":[]}
```
results in:
```
fulcio-server-1        | 2025-09-10T09:39:58.799Z       WARN    server/error.go:57      oidc: malformed jwt, expected 3 parts got 1     {"requestID": "-03xA5aM", "code": "InvalidArgument", "clientMessage": "There was an error processing the identity token", "error": "oidc: malformed jwt, expected 3 parts got 1"}
fulcio-server-1        | github.com/sigstore/fulcio/pkg/server.handleFulcioGRPCError
fulcio-server-1        |        /opt/app-root/src/pkg/server/error.go:57
fulcio-server-1        | github.com/sigstore/fulcio/pkg/server.(*grpcaCAServer).CreateSigningCertificate

<snipped rest of stack trace>
```