### PR TITLE
Add workflow to periodically validate OIDC issuers

### DIFF
--- a/.github/workflows/check-oidc-issuers.yml
+++ b/.github/workflows/check-oidc-issuers.yml
@@ -1,0 +1,85 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow is triggered on a schedule to periodically check the health
+# of the OIDC issuers configured in config/identity/config.yaml.
+# It fetches the /.well-known/openid-configuration for each issuer and
+# creates a GitHub issue if any of them fail to respond with a 200 status.
+name: Check OIDC Issuers
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-issuers:
+    name: Verify OIDC issuer availability
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to file an issue on failure
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install yq
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+
+      - name: Check OIDC issuer configurations
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+
+          ISSUERS=$(yq '.oidc-issuers.*.issuer-url' config/identity/config.yaml)
+
+          for issuer_url in $ISSUERS; do
+            # Some issuer URLs might have a trailing slash, remove it.
+            issuer_url=$(echo "$issuer_url" | sed 's:/*$::')
+            config_url="${issuer_url}/.well-known/openid-configuration"
+            
+            echo "Checking $config_url"
+            
+            # Perform the request and get the HTTP status code
+            status_code=$(curl -s -o /dev/null -w "%{http_code}" --location --max-time 10 "$config_url")
+            
+            if [ "$status_code" -ne 200 ]; then
+              echo "::error::Check for $issuer_url failed with status code $status_code"
+              ISSUE_TITLE="Failed to resolve OIDC configuration for ${issuer_url}"
+              
+              # Check if an open issue with the same title already exists
+              EXISTING_ISSUE=$(gh issue list --search "$ISSUE_TITLE in:title is:open" --json number --jq '.[0].number')
+
+              if [ -z "$EXISTING_ISSUE" ]; then
+                echo "Creating new issue for $issuer_url"
+                gh issue create \
+                  --title "$ISSUE_TITLE" \
+                  --body "The well-known OIDC configuration endpoint for \`${issuer_url}\` returned a non-200 status code: **${status_code}**. Please investigate if the provider is down or if the configuration needs to be updated. Endpoint checked: \`${config_url}\`" \
+                  --label "bug" \
+                  --assignee "sigstore/fulcio-codeowners"
+              else
+                echo "An open issue (#$EXISTING_ISSUE) already exists for $issuer_url"
+              fi
+            else
+              echo "OK: $config_url returned status $status_code"
+            fi
+          done


### PR DESCRIPTION
This workflow will run a nightly check for the availability of all supported OIDC providers, and will file an issue if any become unavailable.

Fixes #2187

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
