### PR TITLE
make email address in test cases rfc822 conformant

### DIFF
--- a/pkg/ca/common_test.go
+++ b/pkg/ca/common_test.go
@@ -73,7 +73,7 @@ func TestMakeX509(t *testing.T) {
 func TestVerifyCertChain(t *testing.T) {
 	rootCert, rootKey, _ := test.GenerateRootCA()
 	subCert, subKey, _ := test.GenerateSubordinateCA(rootCert, rootKey)
-	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
+	leafCert, _, _ := test.GenerateLeafCert("subject@example.com", "oidc-issuer", subCert, subKey)
 
 	err := VerifyCertChain([]*x509.Certificate{subCert, rootCert}, subKey)
 	if err != nil {

--- a/pkg/test/cert_utils.go
+++ b/pkg/test/cert_utils.go
@@ -31,7 +31,7 @@ To use:
 
 rootCert, rootKey, _ := GenerateRootCA()
 subCert, subKey, _ := GenerateSubordinateCa(rootCert, rootKey)
-leafCert, _, _ := GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
+leafCert, _, _ := GenerateLeafCert("subject@example.com", "oidc-issuer", subCert, subKey)
 
 roots := x509.NewCertPool()
 subs := x509.NewCertPool()


### PR DESCRIPTION
when running `go test ./...` using 1.25, these test cases crash because there is stricter SAN validation in certificates in the stdlib. These cases pass in 1.24, but will fail when we upgrade the toolchain.