### PR TITLE
Handle optional environment claim

### DIFF
--- a/config/identity/config.yaml
+++ b/config/identity/config.yaml
@@ -138,6 +138,8 @@ ci-issuer-metadata:
     default-template-values:
       # url: URL of issuer, https://github.com
       url: "https://github.com"
+      # Nil default value to handle optional environment claim
+      environment: ""
     extension-templates:
       # event_name: Event that triggered this workflow run. E.g "push", "tag"
       github-workflow-trigger: "event_name"
@@ -175,12 +177,14 @@ ci-issuer-metadata:
       run-invocation-uri: "{{ .url }}/{{ .repository }}/actions/runs/{{ .run_id }}/attempts/{{ .run_attempt }}"
       # repository_visibility: Visibility of the source repo
       source-repository-visibility-at-signing: "repository_visibility"
-      # environment: Deployment target for workflow
+      # environment: Deployment target for workflow (optional)
       deployment-environment: "environment"
     subject-alternative-name-template: "{{ .url }}/{{ .job_workflow_ref }}"
   *gitlab-type:
     default-template-values:
       url: "https://gitlab.com"
+      # Nil default value to handle optional environment claim
+      environment: ""
     extension-templates:
       # url: The URL of the GitLab instance. https://gitlab.com
       # ci_config_ref_uri: Ref of top-level pipeline definition.
@@ -214,7 +218,7 @@ ci-issuer-metadata:
       run-invocation-uri: "{{ .url }}/{{ .project_path }}/-/jobs/{{ .job_id }}"
       # project_visibility: Visibility of the source project
       source-repository-visibility-at-signing: "project_visibility"
-      # environment: Deployment target for job
+      # environment: Deployment target for job (optional)
       deployment-environment: "environment"
     subject-alternative-name-template: "https://{{ .ci_config_ref_uri }}"
   *codefresh-type:

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -1214,7 +1214,8 @@ func TestAPIWithCiProvider(t *testing.T) {
 			DeploymentEnvironment:               "environment",
 		},
 		DefaultTemplateValues: map[string]string{
-			"url": "https://github.com",
+			"url":         "https://github.com",
+			"environment": "",
 		},
 		SubjectAlternativeNameTemplate: "{{.url}}/{{.job_workflow_ref}}",
 	}


### PR DESCRIPTION
environment is an optional claim for GitHub and GitLab tokens if workflows/jobs don't run in an environment. Fulcio will err out if any configured claims are missing, so as to not issue a certificate with a missing claim unexpectedly. Because environment wasn't set, cert issuance failed for GitHub/GitLab when this was deployed to staging.

The fix is simple thankfully: Just configure a default nil value. When the extensions are rendered, any extensions with a empty/nil value will be skipped over.

This PR fixes the config and adds tests to verify this fix.

This also cleans up comments in the CI provider code.

There are no functional changes in this PR, so no new release is needed.

Fixes #1845

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
