### PR TITLE
Update untrusted OIDC token for e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,8 @@ jobs:
             --out=signing-config.json
 
       - name: Get test OIDC token
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
+        run: |
+          curl -o oidc-token.txt "https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt"
 
       - name: Sign and verify with ID token
         run: |
@@ -68,6 +69,6 @@ jobs:
           cosign verify-blob myblob \
             --insecure-ignore-tlog \
             --trusted-root=trusted-root.json \
-            --certificate-identity=https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity=untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
+            --certificate-oidc-issuer=https://accounts.google.com \
             --bundle=bundle.json


### PR DESCRIPTION
The GHA-based token fetcher has unfortunately become unstable and doesn't run as frequently as needed. We've moved to a Cloud Run-based generator.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
