### PR TITLE
Block cross-host redirects and restrict bearer token to expected host

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,11 +54,20 @@ type verifierWithConfig struct {
 type bearerTokenTransport struct {
 	Transport http.RoundTripper
 	Token     string
+	IssuerURL string
 }
 
 func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.Header.Set("Authorization", "Bearer "+t.Token)
+	parsedIssuer, err := url.Parse(t.IssuerURL)
+	if err != nil {
+		return nil, err
+	}
+	if req.URL.Host == parsedIssuer.Host {
+		req.Header.Set("Authorization", "Bearer "+t.Token)
+	} else {
+		return nil, fmt.Errorf("issuer URL host %s does not match request URL host %s", parsedIssuer.Host, req.URL.Host)
+	}
 	return t.Transport.RoundTrip(req)
 }
 
@@ -186,6 +195,7 @@ func (fc *FulcioConfig) GetIssuer(issuerURL string) (OIDCIssuer, bool) {
 				SubjectDomain:         iss.SubjectDomain,
 				CIProvider:            iss.CIProvider,
 				SkipEmailVerification: iss.SkipEmailVerification,
+				CACert:                iss.CACert,
 			}, true
 		}
 	}
@@ -295,13 +305,23 @@ func (fc *FulcioConfig) ToIssuers() []*fulciogrpc.OIDCIssuer {
 	return issuers
 }
 
+func noRedirectClient(client *http.Client) *http.Client {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+			return fmt.Errorf("oidc: redirect to different host %q blocked", req.URL.Host)
+		}
+		return nil
+	}
+	return client
+}
+
 func httpClientForIssuer(fc *FulcioConfig, iss OIDCIssuer) (*http.Client, error) {
 	transportProvider := func(transport *http.Transport) http.RoundTripper {
 		return transport
 	}
 
 	_, hasK8SIssuer := fc.GetIssuer(k8sIssuerURL)
-	if iss.Type == IssuerTypeKubernetes && hasK8SIssuer {
+	if iss.Type == IssuerTypeKubernetes && hasK8SIssuer && iss.IssuerURL == k8sIssuerURL {
 		// Add the Kubernetes cluster's CA to the client's CA pool
 		certs, err := os.ReadFile(k8sCA)
 		if err != nil {
@@ -319,6 +339,7 @@ func httpClientForIssuer(fc *FulcioConfig, iss OIDCIssuer) (*http.Client, error)
 				return &bearerTokenTransport{
 					Transport: transport,
 					Token:     string(tokenBytes),
+					IssuerURL: iss.IssuerURL,
 				}
 			}
 		} else {
@@ -345,9 +366,9 @@ func httpClientForIssuer(fc *FulcioConfig, iss OIDCIssuer) (*http.Client, error)
 				MinVersion: tls.VersionTLS12,
 			},
 		}
-		return &http.Client{Transport: transportProvider(transport)}, nil
+		return noRedirectClient(&http.Client{Transport: transportProvider(transport)}), nil
 	}
-	return http.DefaultClient, nil
+	return noRedirectClient(&http.Client{Transport: http.DefaultTransport}), nil
 }
 
 func (fc *FulcioConfig) prepare() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1177,3 +1177,233 @@ type mockKeySet struct {
 func (m *mockKeySet) VerifySignature(_ context.Context, _ string) (payload []byte, err error) {
 	return nil, nil
 }
+
+func TestGetVerifier_CrossHostRedirectBlocked(t *testing.T) {
+	// Server B: Redirect target
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   "https://example.com",
+			"jwks_uri": "https://example.com/keys",
+		})
+	}))
+	defer serverB.Close()
+
+	// Server A: Original issuer, redirects to Server B
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			http.Redirect(w, r, serverB.URL, http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer serverA.Close()
+
+	cache, err := lru.New2Q[string, []*verifierWithConfig](100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fc := &FulcioConfig{
+		OIDCIssuers: map[string]OIDCIssuer{
+			serverA.URL: {
+				IssuerURL: serverA.URL,
+				ClientID:  "sigstore",
+			},
+		},
+		verifiers: make(map[string][]*verifierWithConfig),
+		lru:       cache,
+	}
+
+	// This discovery fetch should fail because the cross-host redirect is blocked.
+	_, ok := fc.GetVerifier(serverA.URL)
+	if ok {
+		t.Fatal("expected GetVerifier to fail due to blocked cross-host redirect")
+	}
+}
+
+func TestGetVerifier_SameHostRedirectAllowed(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			http.Redirect(w, r, "/discovery", http.StatusFound)
+		case "/discovery":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":   server.URL,
+				"jwks_uri": server.URL + "/keys",
+			})
+		case "/keys":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"keys": []any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cache, err := lru.New2Q[string, []*verifierWithConfig](100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fc := &FulcioConfig{
+		OIDCIssuers: map[string]OIDCIssuer{
+			server.URL: {
+				IssuerURL: server.URL,
+				ClientID:  "sigstore",
+			},
+		},
+		verifiers: make(map[string][]*verifierWithConfig),
+		lru:       cache,
+	}
+
+	// This discovery fetch should succeed because the redirect stays on the same host.
+	_, ok := fc.GetVerifier(server.URL)
+	if !ok {
+		t.Fatal("expected GetVerifier to succeed with same-host redirect")
+	}
+}
+
+func TestBearerTokenTransport_DifferentHostFails(t *testing.T) {
+	mockTransport := &mockRoundTripper{}
+	transport := &bearerTokenTransport{
+		Transport: mockTransport,
+		Token:     "super-secret-token",
+		IssuerURL: "https://kubernetes.default.svc",
+	}
+
+	// 1. Request to the expected host should have the Bearer token
+	reqSame, _ := http.NewRequest("GET", "https://kubernetes.default.svc/some-endpoint", nil)
+	_, err := transport.RoundTrip(reqSame)
+	if err != nil {
+		t.Fatalf("unexpected error for same-host request: %v", err)
+	}
+	if got := mockTransport.lastHeaders.Get("Authorization"); got != "Bearer super-secret-token" {
+		t.Errorf("expected Authorization header to be 'Bearer super-secret-token', got '%s'", got)
+	}
+
+	// Reset mock transport headers
+	mockTransport.lastHeaders = nil
+
+	// 2. Request to a different host should fail with an error
+	reqDiff, _ := http.NewRequest("GET", "https://attacker.com/some-endpoint", nil)
+	_, err = transport.RoundTrip(reqDiff)
+	if err == nil {
+		t.Error("expected error for cross-host request, got nil")
+	}
+	if mockTransport.lastHeaders != nil {
+		t.Error("expected mock transport to not be called for cross-host request")
+	}
+}
+
+type mockRoundTripper struct {
+	lastHeaders http.Header
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.lastHeaders = req.Header
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func TestGetVerifier_MetaIssuerK8sTokenNotLeaked(t *testing.T) {
+	// Save globals and restore them after the test
+	origK8sCA := k8sCA
+	origK8sTokenFile := k8sTokenFile
+	origK8sIssuerURL := k8sIssuerURL
+	defer func() {
+		k8sCA = origK8sCA
+		k8sTokenFile = origK8sTokenFile
+		k8sIssuerURL = origK8sIssuerURL
+	}()
+
+	caPEM, serverTLSCert, err := createServerTLS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	crtFile, err := mockFile("ca-*.crt", caPEM.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(crtFile.Name())
+	k8sCA = crtFile.Name()
+
+	const token = "super-secret-local-token"
+	tokenFile, err := mockFile("token-*", token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tokenFile.Name())
+	k8sTokenFile = tokenFile.Name()
+
+	// The local Kubernetes issuer URL
+	k8sIssuerURL = "https://kubernetes.default.svc"
+
+	// Set up a mock external server representing the meta-issuer
+	authorized := atomic.Bool{}
+	var server *httptest.Server
+	server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			authorized.Store(true)
+		}
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":   server.URL,
+				"jwks_uri": server.URL + "/keys",
+			})
+		case "/keys":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"keys": []any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverTLSCert},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// Create a meta-issuer that matches the mock external server
+	metaIssuer := strings.ReplaceAll(server.URL, "127.0.0.1", "*.*.*.*")
+
+	fc := &FulcioConfig{
+		OIDCIssuers: map[string]OIDCIssuer{
+			// Local Kubernetes default issuer exists in config
+			k8sIssuerURL: {
+				IssuerURL: k8sIssuerURL,
+				ClientID:  "sigstore",
+				Type:      IssuerTypeKubernetes,
+			},
+		},
+		MetaIssuers: map[string]OIDCIssuer{
+			metaIssuer: {
+				ClientID: "sigstore",
+				Type:     IssuerTypeKubernetes,
+				CACert:   caPEM.String(),
+			},
+		},
+		verifiers: make(map[string][]*verifierWithConfig),
+	}
+
+	if err := fc.prepare(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch verifier for the external meta-issuer server URL
+	_, ok := fc.GetVerifier(server.URL)
+	if !ok {
+		t.Fatal("expected to get verifier")
+	}
+
+	if authorized.Load() {
+		t.Fatal("vulnerability: sensitive local Kubernetes token was leaked to external meta-issuer URL")
+	}
+}


### PR DESCRIPTION
Secures the outbound OIDC discovery request flow against SSRF, JWKS substitution, and credential leakage.

Blocks cross-host redirects: Configures a custom CheckRedirect callback on all OIDC discovery clients to reject redirects that attempt to leave the original issuer's host boundary. SSRF was previously mitigated by adding anchors to the meta issuer regex, but this was not a complete mitigation since a malicious meta issuer could specify an HTTP redirect, which the Go HTTP client would follow by default.

Restricts bearer token injection: Updates bearerTokenTransport to only attach the Kubernetes service-account bearer token when the outgoing request destination host exactly matches the expected issuer's host. This prevents token leakage during both redirect scenarios and cross-host JWKS URIs.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
