### PR TITLE
Allow directly-configured Kubernetes issuers to use in-cluster auth path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -321,7 +321,9 @@ func httpClientForIssuer(fc *FulcioConfig, iss OIDCIssuer) (*http.Client, error)
 	}
 
 	_, hasK8SIssuer := fc.GetIssuer(k8sIssuerURL)
-	if iss.Type == IssuerTypeKubernetes && hasK8SIssuer && iss.IssuerURL == k8sIssuerURL {
+	_, isConfiguredOIDCIssuer := fc.OIDCIssuers[iss.IssuerURL]
+	isTrustedK8sIssuer := isConfiguredOIDCIssuer || iss.IssuerURL == k8sIssuerURL
+	if iss.Type == IssuerTypeKubernetes && hasK8SIssuer && isTrustedK8sIssuer {
 		// Add the Kubernetes cluster's CA to the client's CA pool
 		certs, err := os.ReadFile(k8sCA)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1407,3 +1407,96 @@ func TestGetVerifier_MetaIssuerK8sTokenNotLeaked(t *testing.T) {
 		t.Fatal("vulnerability: sensitive local Kubernetes token was leaked to external meta-issuer URL")
 	}
 }
+
+// TestGetVerifier_DirectConfiguredK8sIssuerGetsToken verifies that a
+// directly-configured Kubernetes-type issuer whose URL is not k8sIssuerURL
+// (e.g. "https://kubernetes.default.svc.cluster.local" used by K3s) still
+// receives the in-cluster CA and projected service-account bearer token.
+func TestGetVerifier_DirectConfiguredK8sIssuerGetsToken(t *testing.T) {
+	origK8sCA := k8sCA
+	origK8sTokenFile := k8sTokenFile
+	origK8sIssuerURL := k8sIssuerURL
+	defer func() {
+		k8sCA = origK8sCA
+		k8sTokenFile = origK8sTokenFile
+		k8sIssuerURL = origK8sIssuerURL
+	}()
+
+	caPEM, serverTLSCert, err := createServerTLS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	crtFile, err := mockFile("ca-*.crt", caPEM.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(crtFile.Name())
+	k8sCA = crtFile.Name()
+
+	const token = "super-secret-local-token"
+	tokenFile, err := mockFile("token-*", token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tokenFile.Name())
+	k8sTokenFile = tokenFile.Name()
+
+	authorized := atomic.Bool{}
+	var server *httptest.Server
+	server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer "+token {
+			authorized.Store(true)
+		}
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":   server.URL,
+				"jwks_uri": server.URL + "/keys",
+			})
+		case "/keys":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"keys": []any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverTLSCert},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	k8sIssuerURL = "https://kubernetes.default.svc"
+
+	fc := &FulcioConfig{
+		OIDCIssuers: map[string]OIDCIssuer{
+			// Present only to satisfy the hasK8SIssuer gate; no request is made to it.
+			k8sIssuerURL: {
+				IssuerURL: k8sIssuerURL,
+				ClientID:  "sigstore",
+				Type:      IssuerTypeKubernetes,
+			},
+			server.URL: {
+				IssuerURL: server.URL,
+				ClientID:  "sigstore",
+				Type:      IssuerTypeKubernetes,
+			},
+		},
+		verifiers: make(map[string][]*verifierWithConfig),
+	}
+
+	if err := fc.prepare(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := fc.GetVerifier(server.URL); !ok {
+		t.Fatal("expected to get verifier")
+	}
+
+	if !authorized.Load() {
+		t.Fatal("expected directly-configured non-default Kubernetes issuer to receive the in-cluster bearer token, but it did not")
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Restore the in-cluster CA + projected service-account bearer-token auth path for directly configured Kubernetes issuers whose issuer URL is not literally `https://kubernetes.default.svc`, while preserving the v1.8.6 SSRF / token-leak protections added in 378c654.

This fixes the regression reported in #2355 for deployments such as K3s, where the service-account issuer may be `https://kubernetes.default.svc.cluster.local` and is explicitly listed in OIDCIssuers.

The existing `TestGetVerifier_MetaIssuerK8sTokenNotLeaked` continues to pass, and a new `TestGetVerifier_DirectConfiguredK8sIssuerGetsToken` covers the K3s case.

Closes #2355 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Fixed a regression introduced in v1.8.6 where Kubernetes-type issuers configured with a non-default URL (e.g. K3s's `https://kubernetes.default.svc.cluster.local`) no longer received the in-cluster CA and service-account bearer token during OIDC discovery.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE