### PR TITLE
Clarify that the algorithm field is ignored and RSA_PSS is PKCS#1 v1.5

### DIFF
--- a/fulcio.proto
+++ b/fulcio.proto
@@ -135,6 +135,10 @@ message PublicKeyRequest {
 message PublicKey {
     /*
      * The cryptographic algorithm to use with the key material
+     *
+     * This field is currently ignored by the server. RSA keys are always
+     * verified as RSA PKCS#1 v1.5 regardless of the value set here. This
+     * will be addressed in a future major version (see issue #1858).
      */
     PublicKeyAlgorithm algorithm = 1;
     /*
@@ -207,6 +211,8 @@ message CertificateChain {
 
 enum PublicKeyAlgorithm {
     PUBLIC_KEY_ALGORITHM_UNSPECIFIED = 0;
+    // The server currently treats this as RSA PKCS#1 v1.5, not RSA-PSS.
+    // True RSA-PSS support will be added in a future major version (see issue #1858).
     RSA_PSS                          = 1;
     ECDSA                            = 2;
     ED25519                          = 3;

--- a/fulcio.swagger.json
+++ b/fulcio.swagger.json
@@ -139,6 +139,7 @@
       "properties": {
         "algorithm": {
           "$ref": "#/definitions/v2PublicKeyAlgorithm",
+          "description": "This field is currently ignored by the server. RSA keys are always\nverified as RSA PKCS#1 v1.5 regardless of the value set here. This\nwill be addressed in a future major version (see issue #1858).",
           "title": "The cryptographic algorithm to use with the key material"
         },
         "content": {
@@ -261,7 +262,8 @@
         "ECDSA",
         "ED25519"
       ],
-      "default": "PUBLIC_KEY_ALGORITHM_UNSPECIFIED"
+      "default": "PUBLIC_KEY_ALGORITHM_UNSPECIFIED",
+      "description": " - RSA_PSS: The server currently treats this as RSA PKCS#1 v1.5, not RSA-PSS.\nTrue RSA-PSS support will be added in a future major version (see issue #1858)."
     },
     "v2PublicKeyRequest": {
       "type": "object",

--- a/pkg/generated/protobuf/fulcio.pb.go
+++ b/pkg/generated/protobuf/fulcio.pb.go
@@ -42,9 +42,11 @@ type PublicKeyAlgorithm int32
 
 const (
 	PublicKeyAlgorithm_PUBLIC_KEY_ALGORITHM_UNSPECIFIED PublicKeyAlgorithm = 0
-	PublicKeyAlgorithm_RSA_PSS                          PublicKeyAlgorithm = 1
-	PublicKeyAlgorithm_ECDSA                            PublicKeyAlgorithm = 2
-	PublicKeyAlgorithm_ED25519                          PublicKeyAlgorithm = 3
+	// The server currently treats this as RSA PKCS#1 v1.5, not RSA-PSS.
+	// True RSA-PSS support will be added in a future major version (see issue #1858).
+	PublicKeyAlgorithm_RSA_PSS PublicKeyAlgorithm = 1
+	PublicKeyAlgorithm_ECDSA   PublicKeyAlgorithm = 2
+	PublicKeyAlgorithm_ED25519 PublicKeyAlgorithm = 3
 )
 
 // Enum value maps for PublicKeyAlgorithm.
@@ -318,6 +320,10 @@ func (x *PublicKeyRequest) GetProofOfPossession() []byte {
 type PublicKey struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The cryptographic algorithm to use with the key material
+	//
+	// This field is currently ignored by the server. RSA keys are always
+	// verified as RSA PKCS#1 v1.5 regardless of the value set here. This
+	// will be addressed in a future major version (see issue #1858).
 	Algorithm PublicKeyAlgorithm `protobuf:"varint,1,opt,name=algorithm,proto3,enum=dev.sigstore.fulcio.v2.PublicKeyAlgorithm" json:"algorithm,omitempty"`
 	// PKIX, ASN.1 DER or PEM-encoded public key. PEM is typically
 	// of type PUBLIC KEY.


### PR DESCRIPTION
## Summary

`PublicKeyAlgorithm` advertises `RSA_PSS` and `PublicKey` exposes an `algorithm` field, but the server never consults the `algorithm` field and verifies RSA keys as PKCS#1 v1.5. As noted in #1858, a client that sent a genuine RSA-PSS proof of possession would fail verification, because the verifier is not given any [PSS options](https://pkg.go.dev/crypto/rsa#PSSOptions).

A full fix (a dedicated RSA-PKCS1v1.5 field plus real RSA-PSS verification) is slated for a future Fulcio major version. In the meantime, this PR makes the proto match the implementation by documenting the current behavior, exactly as @haydentherapper scoped it in the issue thread:

> we can just add a comment to the algorithm enum that says this is actually RSA PKCS#1-v1.5, and add a comment to `algorithm` that this field is currently ignored.

## Changes

- `fulcio.proto`: add a comment on the `algorithm` field noting it is currently ignored by the server, and a comment on the `RSA_PSS` enum value noting it is currently treated as RSA PKCS#1 v1.5 (not RSA-PSS). Both comments point readers to #1858 for the eventual fix.
- Regenerated `pkg/generated/protobuf/fulcio.pb.go` and `fulcio.swagger.json` from the updated proto with `make gen` so the generated sources stay in sync (protoc v35.0, matching `.github/workflows/main.yml`).

This is documentation only; there is no behavior or wire-format change. The serialized file descriptor is unchanged (the diff is comments plus a gofmt realignment of the enum const block).

## Verification

- `make gen` regenerated the protobuf sources cleanly; the only content changes are the two comments propagating into `fulcio.pb.go` (Go doc comments) and `fulcio.swagger.json` (field/enum descriptions).
- `go build ./...` and `go vet ./pkg/generated/protobuf/... ./pkg/server/... ./pkg/challenges/...` pass.
- The `.proto` parses with `protoc --descriptor_set_out=/dev/null`.

Wording credit to @haydentherapper, who proposed this near-term clarification in #1858.

Fixes #1858
