### PR TITLE
fix: add RSA-PSS signature algorithm support

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -331,6 +331,12 @@ func getHashFuncForSignatureAlgorithm(signatureAlgorithm x509.SignatureAlgorithm
 		return crypto.SHA384, nil
 	case x509.SHA512WithRSA:
 		return crypto.SHA512, nil
+	case x509.SHA256WithRSAPSS:
+		return crypto.SHA256, nil
+	case x509.SHA384WithRSAPSS:
+		return crypto.SHA384, nil
+	case x509.SHA512WithRSAPSS:
+		return crypto.SHA512, nil
 	case x509.PureEd25519:
 		return crypto.Hash(0), nil
 	}


### PR DESCRIPTION
## Description

Fixes #1858. Fulcio's API documentation specifies RSA-PSS as a supported algorithm, but the `getHashFuncForSignatureAlgorithm` function was missing cases for RSA-PSS signature algorithms.

## Root Cause

The `getHashFuncForSignatureAlgorithm` function in `pkg/server/grpc_server.go` handled ECDSA, RSA (PKCS#1 v1.5), and Ed25519 signature algorithms, but did not handle:
- `x509.SHA256WithRSAPSS`
- `x509.SHA384WithRSAPSS`  
- `x509.SHA512WithRSAPSS`

This caused CSRs using RSA-PSS signature algorithms to be rejected with an "unrecognized signature algorithm" error.

## Changes

Added the three RSA-PSS signature algorithm cases to `getHashFuncForSignatureAlgorithm`, mapping each to its corresponding hash function (SHA-256, SHA-384, SHA-512).

## Testing

Existing tests should continue to pass. A new test case for RSA-PSS CSRs would be a good addition.
