### PR TITLE
fix: add RSA-PSS signature algorithm support

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -331,6 +331,12 @@ func getHashFuncForSignatureAlgorithm(signatureAlgorithm x509.SignatureAlgorithm
 		return crypto.SHA384, nil
 	case x509.SHA512WithRSA:
 		return crypto.SHA512, nil
+	case x509.SHA256WithRSAPSS:
+		return crypto.SHA256, nil
+	case x509.SHA384WithRSAPSS:
+		return crypto.SHA384, nil
+	case x509.SHA512WithRSAPSS:
+		return crypto.SHA512, nil
 	case x509.PureEd25519:
 		return crypto.Hash(0), nil
 	}


### PR DESCRIPTION
Fixes #1858. The function was missing cases for SHA256WithRSAPSS, SHA384WithRSAPSS, and SHA512WithRSAPSS, causing CSRs with RSA-PSS signature algorithms to be rejected with 'unrecognized signature algorithm' error despite the API documenting RSA-PSS support.

Signed-off-by: Arunesh Dwivedi <arunesh.devops@gmail.com>