### PR TITLE
Update fulcio to have configurable hsm-caroot-id rather than hardcoded

### DIFF
--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -123,6 +123,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().String("grpc-tls-key", "", "the private key file to use for secure connections (without passphrase) - only applies to grpc-port")
 	cmd.Flags().Duration("idle-connection-timeout", 30*time.Second, "The time allowed for connections (HTTP or gRPC) to go idle before being closed by the server")
 	cmd.Flags().String("ct-log.tls-ca-cert", "", "Path to TLS CA certificate used to connect to ct-log")
+	cmd.Flags().String("hsm-key-label", "PKCS11CA", "HSM key label for PKCS11 CA")
 	cmd.Flags().StringSlice("client-signing-algorithms", buildDefaultClientSigningAlgorithms([]v1.PublicKeyDetails{
 		v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
 		v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384,

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -269,6 +269,7 @@ func runServeCmd(cmd *cobra.Command, args []string) { //nolint: revive
 		params := pkcs11ca.Params{
 			ConfigPath: viper.GetString("pkcs11-config-path"),
 			RootID:     viper.GetString("hsm-caroot-id"),
+			KeyLabel:   viper.GetString("hsm-key-label"),
 		}
 		if viper.IsSet("aws-hsm-root-ca-path") {
 			path := viper.GetString("aws-hsm-root-ca-path")

--- a/pkg/ca/pkcs11ca/pkcs11ca.go
+++ b/pkg/ca/pkcs11ca/pkcs11ca.go
@@ -73,7 +73,7 @@ func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	}
 
 	// get the private key object from HSM
-	signer, err := p11Ctx.FindKeyPair(nil, []byte("PKCS11CA"))
+	signer, err := p11Ctx.FindKeyPair(nil, []byte(params.RootID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ca/pkcs11ca/pkcs11ca.go
+++ b/pkg/ca/pkcs11ca/pkcs11ca.go
@@ -79,7 +79,7 @@ func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	    keyLabel = "PKCS11CA"
 	}
 
-	signer, err := p11Ctx.FindKeyPair(nil, []byte(params.keyLabel))
+	signer, err := p11Ctx.FindKeyPair(nil, []byte(keyLabel))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ca/pkcs11ca/pkcs11ca.go
+++ b/pkg/ca/pkcs11ca/pkcs11ca.go
@@ -33,6 +33,7 @@ type Params struct {
 	ConfigPath string
 	RootID     string
 	CAPath     *string
+	KeyLabel   string
 }
 
 type PKCS11CA struct {
@@ -73,7 +74,12 @@ func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	}
 
 	// get the private key object from HSM
-	signer, err := p11Ctx.FindKeyPair(nil, []byte(params.RootID))
+	keyLabel := params.KeyLabel
+	if keyLabel == "" {
+	    keyLabel = "PKCS11CA"
+	}
+
+	signer, err := p11Ctx.FindKeyPair(nil, []byte(params.keyLabel))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ca/pkcs11ca/pkcs11ca.go
+++ b/pkg/ca/pkcs11ca/pkcs11ca.go
@@ -76,9 +76,8 @@ func NewPKCS11CA(params Params) (*PKCS11CA, error) {
 	// get the private key object from HSM
 	keyLabel := params.KeyLabel
 	if keyLabel == "" {
-	    keyLabel = "PKCS11CA"
+		keyLabel = "PKCS11CA"
 	}
-
 	signer, err := p11Ctx.FindKeyPair(nil, []byte(keyLabel))
 	if err != nil {
 		return nil, err

--- a/pkg/ca/pkcs11ca/pkcs11canocgo.go
+++ b/pkg/ca/pkcs11ca/pkcs11canocgo.go
@@ -31,6 +31,7 @@ type Params struct {
 	ConfigPath string
 	RootID     string
 	CAPath     *string
+	KeyLabel   string
 }
 
 // NewPKCS11CA is a placeholder for erroring with a meaningful message if the


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Users to be able to reference a certificate with a different label naming convention rather than just the hardcoded "PKCS11CA"

Closes #2376 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Adding --hsm-key-label flag to fulcio serve command for pkcs11ca backend. This flag allows users to specify a custom PKCS#11 key label when the signing key was not generated with the default PKCS11CA label. Defaults to PKCS11CA for backward compatibility.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

This change adds a new CLI flag for the pkcs11ca backend. The Fulcio HSM documentation should be updated to document the new --hsm-key-label flag alongside the existing --hsm-caroot-id flag, explaining that:
--hsm-caroot-id identifies the certificate in the HSM by ID
--hsm-key-label identifies the signing key pair by label (defaults to PKCS11CA)
