### PR TITLE
docs: clarify RSA_PSS algorithm and ignored field in proto

### DIFF
--- a/fulcio.proto
+++ b/fulcio.proto
@@ -134,7 +134,9 @@ message PublicKeyRequest {
 
 message PublicKey {
     /*
-     * The cryptographic algorithm to use with the key material
+     * The cryptographic algorithm to use with the key material.
+     * This field is currently ignored; the algorithm is inferred from the
+     * public key when it is parsed.
      */
     PublicKeyAlgorithm algorithm = 1;
     /*
@@ -207,6 +209,13 @@ message CertificateChain {
 
 enum PublicKeyAlgorithm {
     PUBLIC_KEY_ALGORITHM_UNSPECIFIED = 0;
+    /*
+     * RSA_PSS is a misnomer: Fulcio currently treats RSA keys as RSA
+     * PKCS#1 v1.5, not RSA-PSS. The signing algorithm is inferred from the
+     * submitted key rather than from this enum, so this value selects RSA
+     * PKCS#1 v1.5. This is kept for backwards compatibility and is expected
+     * to be corrected in a future major version.
+     */
     RSA_PSS                          = 1;
     ECDSA                            = 2;
     ED25519                          = 3;

--- a/fulcio.swagger.json
+++ b/fulcio.swagger.json
@@ -139,7 +139,7 @@
       "properties": {
         "algorithm": {
           "$ref": "#/definitions/v2PublicKeyAlgorithm",
-          "title": "The cryptographic algorithm to use with the key material"
+          "description": "The cryptographic algorithm to use with the key material.\nThis field is currently ignored; the algorithm is inferred from the\npublic key when it is parsed."
         },
         "content": {
           "type": "string",
@@ -261,7 +261,8 @@
         "ECDSA",
         "ED25519"
       ],
-      "default": "PUBLIC_KEY_ALGORITHM_UNSPECIFIED"
+      "default": "PUBLIC_KEY_ALGORITHM_UNSPECIFIED",
+      "description": " - RSA_PSS: RSA_PSS is a misnomer: Fulcio currently treats RSA keys as RSA\nPKCS#1 v1.5, not RSA-PSS. The signing algorithm is inferred from the\nsubmitted key rather than from this enum, so this value selects RSA\nPKCS#1 v1.5. This is kept for backwards compatibility and is expected\nto be corrected in a future major version."
     },
     "v2PublicKeyRequest": {
       "type": "object",

--- a/pkg/generated/protobuf/fulcio.pb.go
+++ b/pkg/generated/protobuf/fulcio.pb.go
@@ -42,9 +42,14 @@ type PublicKeyAlgorithm int32
 
 const (
 	PublicKeyAlgorithm_PUBLIC_KEY_ALGORITHM_UNSPECIFIED PublicKeyAlgorithm = 0
-	PublicKeyAlgorithm_RSA_PSS                          PublicKeyAlgorithm = 1
-	PublicKeyAlgorithm_ECDSA                            PublicKeyAlgorithm = 2
-	PublicKeyAlgorithm_ED25519                          PublicKeyAlgorithm = 3
+	// RSA_PSS is a misnomer: Fulcio currently treats RSA keys as RSA
+	// PKCS#1 v1.5, not RSA-PSS. The signing algorithm is inferred from the
+	// submitted key rather than from this enum, so this value selects RSA
+	// PKCS#1 v1.5. This is kept for backwards compatibility and is expected
+	// to be corrected in a future major version.
+	PublicKeyAlgorithm_RSA_PSS PublicKeyAlgorithm = 1
+	PublicKeyAlgorithm_ECDSA   PublicKeyAlgorithm = 2
+	PublicKeyAlgorithm_ED25519 PublicKeyAlgorithm = 3
 )
 
 // Enum value maps for PublicKeyAlgorithm.
@@ -317,7 +322,9 @@ func (x *PublicKeyRequest) GetProofOfPossession() []byte {
 
 type PublicKey struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The cryptographic algorithm to use with the key material
+	// The cryptographic algorithm to use with the key material.
+	// This field is currently ignored; the algorithm is inferred from the
+	// public key when it is parsed.
 	Algorithm PublicKeyAlgorithm `protobuf:"varint,1,opt,name=algorithm,proto3,enum=dev.sigstore.fulcio.v2.PublicKeyAlgorithm" json:"algorithm,omitempty"`
 	// PKIX, ASN.1 DER or PEM-encoded public key. PEM is typically
 	// of type PUBLIC KEY.


### PR DESCRIPTION
## Summary

Fulcio's API advertises `RSA_PSS` as a supported algorithm, but as noted in #1858:

- the `algorithm` field is not used when parsing the public key (the algorithm is inferred from the submitted key), and
- RSA keys are treated as RSA PKCS#1 v1.5 rather than RSA-PSS.

This adds clarifying comments to `fulcio.proto` (and the regenerated output) so the
API contract is clear to clients, following @haydentherapper's suggestion in the issue
to document the current behaviour now and correct it properly in a future major version.

No behavioural change, comments only.

## Release Note

```release-note
NONE
```

Fixes #1858
