### PR TITLE
ciprovider: validate SubjectAlternativeName is an absolute URI (defense-in-depth)

### DIFF
--- a/pkg/identity/ciprovider/principal.go
+++ b/pkg/identity/ciprovider/principal.go
@@ -156,6 +156,16 @@ func (principal ciPrincipal) Embed(_ context.Context, cert *x509.Certificate) er
 	if err != nil {
 		return err
 	}
+	// Hardening (defense-in-depth): require the SAN to be an absolute URI with a
+	// scheme and host. A ci-provider SAN template is rendered from a mix of
+	// operator DefaultTemplateValues and OIDC token claims (claims take
+	// precedence); constraining the result to an absolute URI prevents a
+	// degenerate or relative value from producing a SAN that a downstream
+	// verifier could mis-interpret. Operators SHOULD additionally pin the SAN
+	// host to an allowlist so an unexpected claim cannot alter the SAN host.
+	if !sanURL.IsAbs() || sanURL.Hostname() == "" {
+		return fmt.Errorf("invalid subject alternative name %q: must be an absolute URI with a scheme and host", subjectAlternativeName)
+	}
 	uris := []*url.URL{sanURL}
 	cert.URIs = uris
 	// We use value.Elem() here because we need an addressable


### PR DESCRIPTION
# Hardening proposal — constrain the `ci-provider` SubjectAlternativeName and protect operator defaults

**Type:** hardening / defense-in-depth (NOT a vulnerability in any shipped/default configuration).
**Component:** `pkg/identity/ciprovider/principal.go` (`ciPrincipal.Embed`, `applyTemplateOrReplace`).
**Channel:** public PR / issue against `sigstore/fulcio` (no embargo needed — not exploitable in the
public-good deployment or in any issuer shipped in `config/identity/config.yaml`).

## Context

The `ci-provider` principal builds a certificate's SubjectAlternativeName (and the Sigstore custom
OID extensions) by rendering operator-configured templates against a data map that merges two
sources (`applyTemplateOrReplace`, principal.go:76-78):

```go
mergedData := make(map[string]string)
maps.Copy(mergedData, issuerMetadata)   // operator DefaultTemplateValues (intended as trusted)
maps.Copy(mergedData, tokenClaims)      // OIDC token claims — copied LAST, so they WIN
```

Two properties combine into a defense-in-depth gap:

1. **Token claims override operator defaults.** Every top-level claim in the (verified) OIDC token
   overrides any `DefaultTemplateValues` entry of the same name. This is intentional for cases like
   self-hosted Codefresh, where `platform_url` legitimately comes from the token. But it means a
   default that an operator treats as a fixed, trusted constant (e.g. the SAN *host*) can be
   displaced by a same-named claim.

2. **The SAN has no host/scheme validation.** Unlike the `uri` provider (which requires an exact
   host match against `SubjectDomain`) and unlike `github`/`gitlab`/`codefresh` (which build SANs
   with `baseURL.JoinPath(...)`), the generic `ci-provider` takes the raw template output and only
   runs `url.Parse` (principal.go:155), which accepts relative/degenerate URIs and does not pin the
   host:

   ```go
   sanURL, err := url.Parse(subjectAlternativeName)  // no scheme/host/allowlist check
   cert.URIs = []*url.URL{sanURL}
   ```

## Why this is not a vulnerability today (shipped config analysis)

Verified against `config/identity/config.yaml` for every shipped `ci-provider` issuer:

| Issuer | SAN host source | Attacker-controllable? |
|--------|-----------------|------------------------|
| github (`token.actions.githubusercontent.com`) | default `url: https://github.com` | No — `url` is not a GitHub OIDC claim; default always used |
| buildkite | default `url: https://buildkite.com` | No — not a claim |
| codefresh | claim `platform_url` (default `https://g.codefresh.io`) | No — set by the Codefresh IdP, not the workflow |
| circleci | claim `api_url` (default `https://circleci.com/api/v2`) | No — set by CircleCI, not the workflow |
| gitlab | claim `ci_config_ref_uri` | No — host set by the GitLab instance |

For every shipped issuer the SAN host is either a fixed default that is not a token claim, or a
claim minted by the trusted IdP that a tenant cannot repoint to a foreign host. So there is **no
identity forgery in the public-good or any shipped deployment**. `Issuer` and `Subject` OID
extensions are additionally force-set from the verified token (principal.go:187-188), so those two
are safe regardless.

The residual risk is limited to a **custom operator configuration**: `ci-provider` is explicitly a
"bring your own CI issuer" extension mechanism, so an operator could add an issuer whose IdP allows
a requester to influence a top-level claim whose name collides with a template key used for the SAN
host. That is an operator-owned misconfiguration, but the toolkit currently offers no guardrail
against it — hence this hardening request.

Also note: the proof-of-possession challenge binds `principal.Name` = `token.Subject`, **not** the
SAN (grpc_server.go:155). SAN values derived from non-`sub` claims are therefore guarded only by the
token signature, which raises the value of validating the SAN itself.

## Proposed changes

### 1. Immediate, non-breaking: require the SAN to be an absolute URI

Patch: `ciprovider-hardening.patch` (compiles; all shipped SAN templates already produce absolute
`https://` URIs, so no behavior change for existing issuers). Rejects relative/degenerate SANs:

```go
if !sanURL.IsAbs() || sanURL.Hostname() == "" {
    return fmt.Errorf("invalid subject alternative name %q: must be an absolute URI with a scheme and host", subjectAlternativeName)
}
```

### 2. Recommended (design discussion): pin the SAN host

Add an optional per-issuer `SubjectAlternativeNameHosts` allowlist (or reuse the existing
`SubjectDomain` concept) in `IssuerMetadata`, and after parsing verify `sanURL.Hostname()` is a
member. This makes an unexpected/injected claim unable to move the SAN off the operator-approved
host set, mirroring the `uri` provider's exact-host guarantee. (Requires a config-schema addition,
so proposing it for maintainer discussion rather than shipping unilaterally.)

### 3. Optional: protect designated defaults from claim override

Allow operators to mark selected `DefaultTemplateValues` keys as non-overridable so a same-named
token claim cannot displace a value the operator intends as a trusted constant (e.g. a host).
Preserves the current claim-wins behavior for keys not marked protected (so Codefresh's
`platform_url` self-hosted use case is unaffected).

## Files
- Patch (change #1): `findings/fulcio/reports/ciprovider-hardening.patch` — `git apply` from repo root.
- Changes #2/#3 are described in prose; happy to draft them if maintainers agree on the config shape.

## Suggested PR/issue title
`ciprovider: validate SubjectAlternativeName is an absolute URI and allow pinning its host (defense-in-depth)`
