### PR TITLE
Add --ct-log-origin flag

### DIFF
--- a/.github/workflows/verify-k8s.yml
+++ b/.github/workflows/verify-k8s.yml
@@ -67,6 +67,7 @@ jobs:
       KO_PREFIX: registry.local:5000/fulcio
       GIT_HASH: ${{ github.sha }}
       GIT_VERSION: test
+      INSECURE_REGISTRY: true
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -198,7 +199,7 @@ jobs:
 
       - name: Validate prometheus metrics exported and look correct
         run: |
-          cat <<EOF | ko apply -f -
+          cat <<EOF | ko apply --insecure-registry -f -
           apiVersion: batch/v1
           kind: Job
           metadata:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ LDFLAGS=-X $(FULCIO_VERSION_PKG).gitVersion=$(GIT_VERSION)
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 
+ifdef INSECURE_REGISTRY
+KO_FLAGS += --insecure-registry
+endif
+
 GHCR_PREFIX ?= ghcr.io/sigstore
 
 FULCIO_YAML ?= fulcio-$(GIT_TAG).yaml
@@ -102,28 +106,28 @@ debug: ## Start docker compose in debug mode
 ko:
 	# fulcio
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve --bare \
+	KO_DOCKER_REPO=$(KO_PREFIX)/fulcio ko resolve --bare $(KO_FLAGS) \
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		--image-refs fulcioImagerefs --filename config/ > $(FULCIO_YAML)
 
 .PHONY: ko-local
 ko-local:
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	ko publish --base-import-paths \
+	ko publish --base-import-paths $(KO_FLAGS) \
 		--platform=linux/amd64 --tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		github.com/sigstore/fulcio
 
 .PHONY: ko-apply
 ko-apply:
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -Bf config/
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply $(KO_FLAGS) -Bf config/
 
 .PHONY: ko-apply-ci
 ko-apply-ci: ko-apply
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -Bf config/test
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply $(KO_FLAGS) -Bf config/test
 
 .PHONY: ko-publish
 ko-publish:
-	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish .
+	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko publish $(KO_FLAGS) .
 
 .PHONY: sign-keyless-ci
 sign-keyless-ci: ko

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -98,6 +98,7 @@ func newServeCmd() *cobra.Command {
 		"Optionally specify /certificateAuthorities/<caID>, which will bypass CA pool load balancing.")
 	cmd.Flags().String("hsm-caroot-id", "", "HSM ID for Root CA (only used with --ca pkcs11ca)")
 	cmd.Flags().String("ct-log-url", "http://localhost:6962/test", "host and path (with log prefix at the end) to the ct log")
+	cmd.Flags().String("ct-log-origin", "", "ct log origin name, if different from the URL")
 	cmd.Flags().String("ct-log-public-key-path", "", "Path to a PEM-encoded public key of the CT log, used to verify SCTs")
 	cmd.Flags().String("config-path", defaultConfigPath, "path to fulcio config yaml")
 	cmd.Flags().String("pkcs11-config-path", "config/crypto11.conf", "path to fulcio pkcs11 config file")
@@ -161,6 +162,28 @@ type logAdaptor struct {
 
 func (la logAdaptor) Printf(s string, args ...any) {
 	la.logger.Infof(s, args...)
+}
+
+type hostRoundTripper struct {
+	http.RoundTripper
+	host string
+}
+
+func (rt *hostRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("http: nil Request")
+	}
+	ctx := req.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req = req.Clone(ctx)
+	req.Host = rt.host
+	inner := rt.RoundTripper
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return inner.RoundTrip(req)
 }
 
 func runServeCmd(cmd *cobra.Command, args []string) { //nolint: revive
@@ -347,6 +370,16 @@ func runServeCmd(cmd *cobra.Command, args []string) { //nolint: revive
 		} else {
 			httpClient = &http.Client{
 				Timeout: 30 * time.Second,
+			}
+		}
+		if origin := viper.GetString("ct-log-origin"); origin != "" {
+			inner := httpClient.Transport
+			if inner == nil {
+				inner = http.DefaultTransport
+			}
+			httpClient.Transport = &hostRoundTripper{
+				RoundTripper: inner,
+				host:         origin,
 			}
 		}
 		ctClient, err = ctclient.New(logURL, httpClient, opts)

--- a/cmd/app/serve_test.go
+++ b/cmd/app/serve_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -139,4 +140,63 @@ func TestDuplex(t *testing.T) {
 			t.Fatalf("/healthz returned status code %d, want 200", code)
 		}
 	})
+}
+
+func TestHostRoundTripper(t *testing.T) {
+	var receivedHost string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	rt := &hostRoundTripper{
+		RoundTripper: http.DefaultTransport,
+		host:         "custom.ct.log.origin",
+	}
+	client := &http.Client{Transport: rt}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if receivedHost != "custom.ct.log.origin" {
+		t.Errorf("expected host 'custom.ct.log.origin', got '%s'", receivedHost)
+	}
+
+	// Also test when inner RoundTripper is nil
+	rtNil := &hostRoundTripper{
+		host: "custom.ct.log.origin.nil",
+	}
+	clientNil := &http.Client{Transport: rtNil}
+
+	reqNil, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	respNil, err := clientNil.Do(reqNil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respNil.Body.Close()
+
+	if receivedHost != "custom.ct.log.origin.nil" {
+		t.Errorf("expected host 'custom.ct.log.origin.nil', got '%s'", receivedHost)
+	}
+}
+
+func TestServeCmdFlags(t *testing.T) {
+	cmd := newServeCmd()
+	f := cmd.Flags().Lookup("ct-log-origin")
+	if f == nil {
+		t.Fatal("expected flag ct-log-origin to exist on serve command")
+	}
 }


### PR DESCRIPTION
Since the move to TesseraCT, the logs are clogged with the warning "AddPreChain the request was received on a URL which is not prefixed with the configured origin". This is because Fulcio is accessing the CT log in-cluster from its Kubernetes service name instead of its public name. This is intentional to avoid an external network round trip, but TesseraCT is semi-strict about the host name it was reached on. This change adds an override to declare the CT log's origin name while still keeping the URL as the actual address to contact.

Generated by Gemini.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
