### PR TITLE
Include CT log error body in logs

### DIFF
--- a/pkg/server/error.go
+++ b/pkg/server/error.go
@@ -17,7 +17,9 @@ package server
 
 import (
 	"context"
+	"errors"
 
+	ctclient "github.com/google/certificate-transparency-go/client"
 	"github.com/sigstore/fulcio/pkg/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,6 +44,11 @@ const (
 )
 
 func handleFulcioGRPCError(ctx context.Context, code codes.Code, err error, message string, fields ...any) error {
+	var rspErr ctclient.RspError
+	if errors.As(err, &rspErr) {
+		fields = append(fields, "body", string(rspErr.Body))
+	}
+
 	// Use log level "warning" for codes that are likely client errors, see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
 	switch code {
 	case codes.InvalidArgument,

--- a/pkg/server/error_test.go
+++ b/pkg/server/error_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ctclient "github.com/google/certificate-transparency-go/client"
+	"github.com/sigstore/fulcio/pkg/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc/codes"
+)
+
+func TestHandleFulcioGRPCError_RspError(t *testing.T) {
+	// Setup observer logger to capture logs
+	core, recorded := observer.New(zap.DebugLevel)
+	observedLogger := zap.New(core).Sugar()
+
+	// Save original logger and restore after test
+	origLogger := log.Logger
+	log.Logger = observedLogger
+	defer func() { log.Logger = origLogger }()
+
+	// Create a client.RspError
+	rspErr := ctclient.RspError{
+		Err:        errors.New("some ct error"),
+		StatusCode: 400,
+		Body:       []byte("detailed error message from CT log"),
+	}
+
+	ctx := context.Background()
+	_ = handleFulcioGRPCError(ctx, codes.Internal, rspErr, "test message")
+
+	// Verify logs
+	if recorded.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", recorded.Len())
+	}
+
+	logEntry := recorded.All()[0]
+	if logEntry.Message != rspErr.Error() {
+		t.Errorf("expected log message to be %q, got %q", rspErr.Error(), logEntry.Message)
+	}
+
+	// Check if "body" field is present in context fields
+	var foundBody bool
+	for _, field := range logEntry.Context {
+		if field.Key == "body" {
+			foundBody = true
+			if field.String != "detailed error message from CT log" {
+				t.Errorf("expected body field to be %q, got %q", "detailed error message from CT log", field.String)
+			}
+		}
+	}
+	if !foundBody {
+		t.Error("expected 'body' field in log context, but not found")
+	}
+}
+
+func TestHandleFulcioGRPCError_NormalError(t *testing.T) {
+	core, recorded := observer.New(zap.DebugLevel)
+	observedLogger := zap.New(core).Sugar()
+
+	origLogger := log.Logger
+	log.Logger = observedLogger
+	defer func() { log.Logger = origLogger }()
+
+	normalErr := errors.New("normal error")
+
+	ctx := context.Background()
+	_ = handleFulcioGRPCError(ctx, codes.Internal, normalErr, "test message")
+
+	if recorded.Len() != 1 {
+		t.Fatalf("expected 1 log entry, got %d", recorded.Len())
+	}
+
+	logEntry := recorded.All()[0]
+	for _, field := range logEntry.Context {
+		if field.Key == "body" {
+			t.Error("unexpected 'body' field in log context for normal error")
+		}
+	}
+}


### PR DESCRIPTION
certificate-transparency-go bundles the important information from a CT log error in the Body field of the error[1], not the Error field, so the .Error() method does not necessarily capture the problem and results in cryptic log messages like 'got HTTP status "500 Internal Server Error"'. This change extract the crucial data and adds it to the log.

[1] https://github.com/google/certificate-transparency-go/blob/v1.3.3/jsonclient/client.go#L117-L126

Relates to https://github.com/sigstore/public-good-instance/issues/3763

Generated by Gemini
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
