### PR TITLE
fix(ciprovider): format large whole-number claims without scientific notation

### DIFF
--- a/pkg/identity/ciprovider/principal.go
+++ b/pkg/identity/ciprovider/principal.go
@@ -42,10 +42,7 @@ func mapValuesToString(claims map[string]any) map[string]string {
 		case reflect.Float32, reflect.Float64:
 			value := vType.Interface().(float64)
 			if value == math.Trunc(value) {
-				// A float, but with no fractional part. Treat as an int.
-				// Format it explicitly rather than with %v, which switches to
-				// scientific notation once the value reaches 1e6 and would put
-				// e.g. "1.753e+09" in the certificate for an exp/iat claim.
+				// A float, but with no fractional part. Treat as an int
 				newMap[k] = strconv.FormatFloat(math.Trunc(value), 'f', -1, 64)
 			} else {
 				newMap[k] = strconv.FormatFloat(value, 'f', -1, 64)

--- a/pkg/identity/ciprovider/principal.go
+++ b/pkg/identity/ciprovider/principal.go
@@ -42,8 +42,11 @@ func mapValuesToString(claims map[string]any) map[string]string {
 		case reflect.Float32, reflect.Float64:
 			value := vType.Interface().(float64)
 			if value == math.Trunc(value) {
-				// A float, but with no fractional part. Treat as an int
-				newMap[k] = fmt.Sprintf("%v", math.Trunc(value))
+				// A float, but with no fractional part. Treat as an int.
+				// Format it explicitly rather than with %v, which switches to
+				// scientific notation once the value reaches 1e6 and would put
+				// e.g. "1.753e+09" in the certificate for an exp/iat claim.
+				newMap[k] = strconv.FormatFloat(math.Trunc(value), 'f', -1, 64)
 			} else {
 				newMap[k] = strconv.FormatFloat(value, 'f', -1, 64)
 			}

--- a/pkg/identity/ciprovider/principal_test.go
+++ b/pkg/identity/ciprovider/principal_test.go
@@ -220,16 +220,18 @@ func TestName(t *testing.T) {
 func TestGetTokenClaims(t *testing.T) {
 
 	tokenClaims := map[string]any{
-		"aud":                "sigstore",
-		"exp":                "0",
-		"iss":                "https://example.com",
-		"claim_string":       "bar",
-		"claim_string_empty": "",
-		"claim_bool":         true,
-		"claim_int":          1,
-		"claim_float_zero":   1.0,
-		"claim_float_low":    1.4,
-		"claim_float_high":   1.7,
+		"aud":                 "sigstore",
+		"exp":                 "0",
+		"iss":                 "https://example.com",
+		"claim_string":        "bar",
+		"claim_string_empty":  "",
+		"claim_bool":          true,
+		"claim_int":           1,
+		"claim_float_zero":    1.0,
+		"claim_float_low":     1.4,
+		"claim_float_high":    1.7,
+		"claim_float_million": 1000000.0,
+		"claim_float_ts":      1753000000.0,
 	}
 
 	tests := map[string]struct {
@@ -278,6 +280,18 @@ func TestGetTokenClaims(t *testing.T) {
 			InputClaims:    tokenClaims,
 			Claim:          "claim_float_high",
 			ExpectedResult: "1.7",
+			ExpectErr:      false,
+		},
+		`large whole-number float claims keep their decimal form`: {
+			InputClaims:    tokenClaims,
+			Claim:          "claim_float_million",
+			ExpectedResult: "1000000",
+			ExpectErr:      false,
+		},
+		`timestamp claims keep their decimal form`: {
+			InputClaims:    tokenClaims,
+			Claim:          "claim_float_ts",
+			ExpectedResult: "1753000000",
 			ExpectErr:      false,
 		},
 		`token has no claims`: {


### PR DESCRIPTION
## Summary

`mapValuesToString` formats whole-number float claims with `fmt.Sprintf("%v", ...)`. For a float64 that switches to scientific notation once the value reaches 1e6, so any numeric OIDC claim at or above a million ends up in the certificate in exponent form.

The sibling branch for fractional floats already does the right thing with `strconv.FormatFloat(value, 'f', -1, 64)`, so this just makes the whole-number branch consistent with it.

What it looks like today:

- `1000000` becomes `1e+06`
- `1753000000`, an ordinary `exp` / `iat` / `nbf`, becomes `1.753e+09`
- GitLab's `project_id` and `user_id` are affected once they pass a million

These values are what `applyTemplateOrReplace` then interpolates into the SAN and the extension values, so the mangled form is what gets written to the issued certificate.

Values below 1e6 are unchanged, and fractional claims keep their current formatting.

## Testing

`TestGetTokenClaims` already distinguishes ints from floats but never exercises magnitude, so I added two cases there. Without the change they fail with:

```
Expected 1753000000, received 1.753e+09
Expected 1000000, received 1e+06
```

With it, `go test ./pkg/identity/...` is green.
