### PR TITLE
feat: serve TLS on HTTP/duplex and make TLS policy configurable

### DIFF
--- a/cmd/app/grpc.go
+++ b/cmd/app/grpc.go
@@ -35,6 +35,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sigstore/fulcio/internal/tlspolicy"
 	"github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/config"
 	gw "github.com/sigstore/fulcio/pkg/generated/protobuf"
@@ -107,7 +108,7 @@ func newCachedTLSCert(certPath, keyPath string) (*cachedTLSCert, error) {
 					return
 				}
 				if event.Has(fsnotify.Write) {
-					log.Logger.Info("fsnotify grpc-tls-certificate write event detected")
+					log.Logger.Info("fsnotify tls-certificate write event detected")
 					if err := cachedTLSCert.UpdateCertificate(); err != nil {
 						log.Logger.Error(err)
 					}
@@ -116,7 +117,7 @@ func newCachedTLSCert(certPath, keyPath string) (*cachedTLSCert, error) {
 				if !ok {
 					return
 				}
-				log.Logger.Error("fsnotify grpc-tls-certificate error:", err)
+				log.Logger.Error("fsnotify tls-certificate error:", err)
 			}
 		}
 	}()
@@ -142,20 +143,30 @@ func (c *cachedTLSCert) UpdateCertificate() error {
 
 	cert, err := tls.LoadX509KeyPair(c.certPath, c.keyPath)
 	if err != nil {
-		return fmt.Errorf("loading GRPC tls certificate and key file: %w", err)
+		return fmt.Errorf("loading tls certificate and key file: %w", err)
 	}
 
 	c.cert = &cert
 	return nil
 }
 
-func (c *cachedTLSCert) GRPCCreds() grpc.ServerOption {
-	return grpc.Creds(credentials.NewTLS(&tls.Config{
+// tlsConfig builds a *tls.Config that serves the watched certificate under the
+// supplied policy. nextProtos advertises the ALPN protocol list (nil for gRPC,
+// which negotiates HTTP/2 via its own credentials).
+func (c *cachedTLSCert) tlsConfig(p tlspolicy.Policy, nextProtos []string) *tls.Config {
+	/* #nosec G402 */ // MinVersion is a variable, but tlspolicy.ParseVersion constrains it to TLS 1.2 or 1.3 and callers default it to a literal >= TLS 1.2, so it is never below the G402 floor.
+	return &tls.Config{
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return c.GetCertificate(), nil
 		},
-		MinVersion: tls.VersionTLS13,
-	}))
+		MinVersion:   p.MinVersion,
+		CipherSuites: p.CipherSuites,
+		NextProtos:   nextProtos,
+	}
+}
+
+func (c *cachedTLSCert) GRPCCreds(p tlspolicy.Policy) grpc.ServerOption {
+	return grpc.Creds(credentials.NewTLS(c.tlsConfig(p, nil)))
 }
 
 func createGRPCServer(cfg *config.FulcioConfig, ctClient *ctclient.LogClient, baseca ca.CertificateAuthority, algorithmRegistry *signature.AlgorithmRegistryConfig, ip identity.IssuerPool) (*grpcServer, error) {
@@ -187,8 +198,13 @@ func createGRPCServer(cfg *config.FulcioConfig, ctClient *ctclient.LogClient, ba
 			return nil, err
 		}
 
+		policy, err := resolveTLSPolicy()
+		if err != nil {
+			return nil, err
+		}
+
 		tlsCertWatcher = cachedTLSCert.Watcher
-		serverOpts = append(serverOpts, cachedTLSCert.GRPCCreds())
+		serverOpts = append(serverOpts, cachedTLSCert.GRPCCreds(policy))
 	}
 
 	myServer := grpc.NewServer(serverOpts...)

--- a/cmd/app/http.go
+++ b/cmd/app/http.go
@@ -30,9 +30,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
+	"github.com/sigstore/fulcio/internal/tlspolicy"
 	gw "github.com/sigstore/fulcio/pkg/generated/protobuf"
 	legacy_gw "github.com/sigstore/fulcio/pkg/generated/protobuf/legacy"
 	"github.com/sigstore/fulcio/pkg/log"
@@ -49,6 +51,7 @@ import (
 type httpServer struct {
 	*http.Server
 	httpServerEndpoint string
+	tlsCertWatcher     *fsnotify.Watcher
 }
 
 func extractOIDCTokenFromAuthHeader(_ context.Context, req *http.Request) metadata.MD {
@@ -112,11 +115,31 @@ func createHTTPServer(ctx context.Context, serverEndpoint string, grpcServer, le
 		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       viper.GetDuration("idle-connection-timeout"),
 	}
-	return httpServer{&api, serverEndpoint}
+
+	// Optionally terminate TLS on the HTTP listener. cachedTLSCert serves the
+	// certificate so on-disk rotation is picked up without a restart.
+	var tlsCertWatcher *fsnotify.Watcher
+	if viper.IsSet("http-tls-certificate") && viper.IsSet("http-tls-key") {
+		cachedTLSCert, err := newCachedTLSCert(viper.GetString("http-tls-certificate"), viper.GetString("http-tls-key"))
+		if err != nil {
+			log.Logger.Fatal(err)
+		}
+		policy, err := resolveTLSPolicy()
+		if err != nil {
+			log.Logger.Fatal(err)
+		}
+		api.TLSConfig = cachedTLSCert.tlsConfig(policy, tlspolicy.ALPNProtocols)
+		tlsCertWatcher = cachedTLSCert.Watcher
+	}
+	return httpServer{&api, serverEndpoint, tlsCertWatcher}
 }
 
 func (h httpServer) startListener(wg *sync.WaitGroup) {
-	log.Logger.Infof("listening on http at %s", h.httpServerEndpoint)
+	scheme := "http"
+	if h.TLSConfig != nil {
+		scheme = "https"
+	}
+	log.Logger.Infof("listening on %s at %s", scheme, h.httpServerEndpoint)
 
 	idleConnsClosed := make(chan struct{})
 	go func() {
@@ -135,7 +158,18 @@ func (h httpServer) startListener(wg *sync.WaitGroup) {
 
 	wg.Add(1)
 	go func() {
-		if err := h.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if h.tlsCertWatcher != nil {
+			defer h.tlsCertWatcher.Close()
+		}
+		// The certificate and key are supplied via TLSConfig.GetCertificate, so
+		// the file arguments are intentionally empty.
+		var err error
+		if h.TLSConfig != nil {
+			err = h.ListenAndServeTLS("", "")
+		} else {
+			err = h.ListenAndServe()
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Logger.Fatal(err)
 		}
 		<-idleConnsClosed

--- a/cmd/app/serve.go
+++ b/cmd/app/serve.go
@@ -48,6 +48,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sigstore/fulcio/internal/tlspolicy"
 	certauth "github.com/sigstore/fulcio/pkg/ca"
 	"github.com/sigstore/fulcio/pkg/ca/ephemeralca"
 	"github.com/sigstore/fulcio/pkg/ca/fileca"
@@ -70,6 +71,7 @@ import (
 	"goa.design/goa/v3/grpc/middleware"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
@@ -122,6 +124,10 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().Duration("read-header-timeout", 10*time.Second, "The time allowed to read the headers of the requests in seconds")
 	cmd.Flags().String("grpc-tls-certificate", "", "the certificate file to use for secure connections - only applies to grpc-port")
 	cmd.Flags().String("grpc-tls-key", "", "the private key file to use for secure connections (without passphrase) - only applies to grpc-port")
+	cmd.Flags().String("http-tls-certificate", "", "the certificate file to use for secure connections on the HTTP endpoint (two-listener mode) and the shared listener (duplex mode)")
+	cmd.Flags().String("http-tls-key", "", "the private key file to use for secure connections (without passphrase) on the HTTP endpoint (two-listener mode) and the shared listener (duplex mode)")
+	cmd.Flags().String("tls-min-version", "", "minimum TLS version for all serving paths (1.2 or 1.3); when unset defaults to 1.3. Lower to 1.2 for peers that cannot negotiate TLS 1.3.")
+	cmd.Flags().StringSlice("tls-cipher-suites", nil, "allowed TLS 1.2 cipher suite names (crypto/tls spelling) applied to all serving paths; empty keeps the crypto/tls default. Has no effect on TLS 1.3.")
 	cmd.Flags().Duration("idle-connection-timeout", 30*time.Second, "The time allowed for connections (HTTP or gRPC) to go idle before being closed by the server")
 	cmd.Flags().String("ct-log.tls-ca-cert", "", "Path to TLS CA certificate used to connect to ct-log")
 	cmd.Flags().String("hsm-key-label", "PKCS11CA", "HSM key label for PKCS11 CA")
@@ -186,6 +192,24 @@ func (rt *hostRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	return inner.RoundTrip(req)
 }
 
+func resolveTLSPolicy() (tlspolicy.Policy, error) {
+	return tlspolicy.Resolve(viper.GetString("tls-min-version"), viper.GetStringSlice("tls-cipher-suites"))
+}
+
+// validateTLSFlags rejects a certificate supplied without its matching key on
+// either serving path before any listener starts. The minimum version and
+// cipher suite flags are validated by resolveTLSPolicy where the policy is
+// applied.
+func validateTLSFlags() error {
+	if viper.IsSet("grpc-tls-certificate") != viper.IsSet("grpc-tls-key") {
+		return fmt.Errorf("--grpc-tls-certificate and --grpc-tls-key must be set together")
+	}
+	if viper.IsSet("http-tls-certificate") != viper.IsSet("http-tls-key") {
+		return fmt.Errorf("--http-tls-certificate and --http-tls-key must be set together")
+	}
+	return nil
+}
+
 func runServeCmd(cmd *cobra.Command, args []string) { //nolint: revive
 	ctx := cmd.Context()
 	// If a config file is provided, modify the viper config to locate and read it
@@ -200,6 +224,10 @@ func runServeCmd(cmd *cobra.Command, args []string) { //nolint: revive
 	// Allow recognition of environment variables such as FULCIO_SERVE_CA etc.
 	viper.SetEnvPrefix(serveCmdEnvPrefix)
 	viper.AutomaticEnv()
+
+	if err := validateTLSFlags(); err != nil {
+		log.Logger.Fatal(err)
+	}
 
 	switch viper.GetString("ca") {
 	case "":
@@ -498,9 +526,38 @@ func StartDuplexServer(ctx context.Context, cfg *config.FulcioConfig, ctClient *
 		grpc_prometheus.WithServerHandlingTimeHistogram(),
 	)
 
+	// Resolve optional TLS on the shared duplex listener up front. The duplex
+	// gateway dials itself over the loopback to translate REST to gRPC, so when
+	// the listener terminates TLS that in-process dial must use TLS credentials
+	// too, otherwise the REST endpoint fails against its own gRPC backend.
+	var (
+		cachedCert *cachedTLSCert
+		policy     tlspolicy.Policy
+		tlsEnabled bool
+	)
+	if viper.IsSet("http-tls-certificate") && viper.IsSet("http-tls-key") {
+		var err error
+		cachedCert, err = newCachedTLSCert(viper.GetString("http-tls-certificate"), viper.GetString("http-tls-key"))
+		if err != nil {
+			return fmt.Errorf("loading duplex TLS certificate: %w", err)
+		}
+		defer cachedCert.Watcher.Close()
+		policy, err = resolveTLSPolicy()
+		if err != nil {
+			return err
+		}
+		tlsEnabled = true
+	}
+
+	loopbackCreds := insecure.NewCredentials()
+	if tlsEnabled {
+		/* #nosec G402 */ // InsecureSkipVerify is only used for the in-process loopback dial to the TLS-enabled duplex listener.
+		loopbackCreds = credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
+	}
+
 	d := duplex.New(
 		port,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(loopbackCreds),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle: viper.GetDuration("idle-connection-timeout"),
 		}),
@@ -558,6 +615,13 @@ func StartDuplexServer(ctx context.Context, cfg *config.FulcioConfig, ctClient *
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return fmt.Errorf("creating listener: %w", err)
+	}
+
+	// Wrap the shared listener with TLS when configured so the duplex server
+	// negotiates HTTP/2 (required by gRPC) over TLS via ALPN.
+	if tlsEnabled {
+		lis = tls.NewListener(lis, cachedCert.tlsConfig(policy, tlspolicy.ALPNProtocols))
+		logger.Info("Duplex server TLS enabled")
 	}
 	logger.Info("Starting duplex server...")
 	if err := d.Serve(ctx, lis); err != nil {

--- a/cmd/app/serve_test.go
+++ b/cmd/app/serve_test.go
@@ -17,13 +17,18 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +40,7 @@ import (
 	"github.com/sigstore/fulcio/pkg/generated/protobuf"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -202,5 +208,296 @@ func TestServeCmdFlags(t *testing.T) {
 	f := cmd.Flags().Lookup("ct-log-origin")
 	if f == nil {
 		t.Fatal("expected flag ct-log-origin to exist on serve command")
+	}
+}
+
+func TestResolveTLSPolicy(t *testing.T) {
+	viper.Set("tls-min-version", "")
+	viper.Set("tls-cipher-suites", nil)
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		p, err := resolveTLSPolicy()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.MinVersion != tls.VersionTLS13 {
+			t.Errorf("minVersion = %#x, want default %#x", p.MinVersion, tls.VersionTLS13)
+		}
+		if p.CipherSuites != nil {
+			t.Errorf("cipherSuites = %v, want nil", p.CipherSuites)
+		}
+	})
+
+	t.Run("override min and ciphers", func(t *testing.T) {
+		viper.Set("tls-min-version", "1.2")
+		viper.Set("tls-cipher-suites", []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"})
+		defer func() {
+			viper.Set("tls-min-version", "")
+			viper.Set("tls-cipher-suites", nil)
+		}()
+		p, err := resolveTLSPolicy()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.MinVersion != tls.VersionTLS12 {
+			t.Errorf("minVersion = %#x, want %#x", p.MinVersion, tls.VersionTLS12)
+		}
+		if len(p.CipherSuites) != 1 {
+			t.Errorf("cipherSuites = %v, want one entry", p.CipherSuites)
+		}
+	})
+
+	t.Run("invalid min version errors", func(t *testing.T) {
+		viper.Set("tls-min-version", "1.1")
+		defer viper.Set("tls-min-version", "")
+		if _, err := resolveTLSPolicy(); err == nil {
+			t.Fatal("expected error for unsupported version")
+		}
+	})
+
+	t.Run("invalid cipher suite errors", func(t *testing.T) {
+		viper.Set("tls-cipher-suites", []string{"NOT_A_REAL_SUITE"})
+		defer viper.Set("tls-cipher-suites", nil)
+		if _, err := resolveTLSPolicy(); err == nil {
+			t.Fatal("expected error for unknown cipher suite")
+		}
+	})
+}
+
+func TestValidateTLSFlags(t *testing.T) {
+	// This is the first code in the package to touch the http-tls-* keys, so
+	// they start unset here.
+	t.Run("http cert without key fails", func(t *testing.T) {
+		viper.Set("http-tls-certificate", "/tmp/cert.pem")
+		if err := validateTLSFlags(); err == nil {
+			t.Fatal("expected error when http cert set without key")
+		}
+	})
+
+	t.Run("http cert and key together pass", func(t *testing.T) {
+		viper.Set("http-tls-certificate", "/tmp/cert.pem")
+		viper.Set("http-tls-key", "/tmp/key.pem")
+		if err := validateTLSFlags(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// TestDuplexTLS exercises the duplex serving path with TLS enabled end to end:
+// the REST endpoint must be reachable over HTTPS and a client that caps below
+// the default TLS 1.3 floor must be rejected by the server.
+func TestDuplexTLS(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte(certPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(keyPath, []byte(keyPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	viper.Set("http-tls-certificate", certPath)
+	viper.Set("http-tls-key", keyPath)
+	viper.Set("tls-min-version", "")
+	viper.Set("tls-cipher-suites", nil)
+	defer func() {
+		viper.Set("http-tls-certificate", "")
+		viper.Set("http-tls-key", "")
+	}()
+
+	ca, err := ephemeralca.NewEphemeralCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	algorithmRegistry, err := signature.NewAlgorithmRegistryConfig([]v1.PublicKeyDetails{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const port = 8090
+	const metricsPort = 2115
+	go func() {
+		// StartDuplexServer blocks; it is intentionally leaked for the lifetime
+		// of the test binary, matching TestDuplex.
+		_ = StartDuplexServer(context.Background(), config.DefaultConfig, nil, ca, algorithmRegistry, "localhost", port, metricsPort, nil)
+	}()
+
+	addr := fmt.Sprintf("localhost:%d", port)
+	// Wait for the TLS listener to come up.
+	var ready bool
+	for i := 0; i < 50; i++ {
+		conn, derr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) // #nosec G402 -- test client
+		if derr == nil {
+			conn.Close()
+			ready = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("duplex TLS server did not become ready")
+	}
+
+	t.Run("https REST endpoint reachable", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- test client
+			},
+		}
+		resp, err := client.Get(fmt.Sprintf("https://%s/healthz", addr))
+		if err != nil {
+			t.Fatalf("HTTPS request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("/healthz returned %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("below-floor TLS version rejected", func(t *testing.T) {
+		// Cap the client at TLS 1.2; the server's default 1.3 floor must reject it.
+		_, err := tls.Dial("tcp", addr, &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 -- test client
+			MinVersion:         tls.VersionTLS12,
+			MaxVersion:         tls.VersionTLS12,
+		})
+		if err == nil {
+			t.Fatal("expected handshake to fail for TLS < 1.3")
+		}
+	})
+}
+
+// writeTLSKeyPair writes the shared test certificate and key to a temp dir and
+// returns their paths.
+func writeTLSKeyPair(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte(certPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(keyPath, []byte(keyPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+// TestCreateHTTPServerTLS verifies that supplying the http-tls flags configures
+// the HTTP server to terminate TLS with the resolved policy (default 1.3 floor
+// and the HTTP/2-first ALPN list).
+func TestCreateHTTPServerTLS(t *testing.T) {
+	certPath, keyPath := writeTLSKeyPair(t)
+
+	viper.Set("grpc-host", "")
+	viper.Set("grpc-port", 0)
+	viper.Set("grpc-tls-certificate", certPath)
+	viper.Set("grpc-tls-key", keyPath)
+	viper.Set("http-tls-certificate", certPath)
+	viper.Set("http-tls-key", keyPath)
+	viper.Set("tls-min-version", "")
+	viper.Set("tls-cipher-suites", nil)
+	defer func() {
+		viper.Set("http-tls-certificate", "")
+		viper.Set("http-tls-key", "")
+	}()
+
+	algorithmRegistry, err := signature.NewAlgorithmRegistryConfig([]v1.PublicKeyDetails{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grpcServer, err := createGRPCServer(nil, nil, &TrivialCertificateAuthority{}, algorithmRegistry, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grpcServer.tlsCertWatcher != nil {
+		defer grpcServer.tlsCertWatcher.Close()
+	}
+
+	srv := createHTTPServer(context.Background(), "localhost:0", grpcServer, nil)
+	if srv.tlsCertWatcher != nil {
+		defer srv.tlsCertWatcher.Close()
+	}
+	if srv.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set when http-tls-* provided")
+	}
+	if srv.TLSConfig.MinVersion != tls.VersionTLS13 {
+		t.Errorf("MinVersion = %#x, want default %#x", srv.TLSConfig.MinVersion, tls.VersionTLS13)
+	}
+	if len(srv.TLSConfig.NextProtos) == 0 || srv.TLSConfig.NextProtos[0] != "h2" {
+		t.Errorf("NextProtos = %v, want h2 first", srv.TLSConfig.NextProtos)
+	}
+}
+
+// TestStartListenerTLS exercises the HTTP startListener TLS path end to end: the
+// server must complete a TLS 1.3 handshake and reject a client that caps below
+// the default 1.3 floor.
+func TestStartListenerTLS(t *testing.T) {
+	certPath, keyPath := writeTLSKeyPair(t)
+
+	// Reserve a concrete port for ListenAndServeTLS, then release it.
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	viper.Set("grpc-host", "")
+	viper.Set("grpc-port", 0)
+	viper.Set("grpc-tls-certificate", certPath)
+	viper.Set("grpc-tls-key", keyPath)
+	viper.Set("http-tls-certificate", certPath)
+	viper.Set("http-tls-key", keyPath)
+	viper.Set("tls-min-version", "")
+	viper.Set("tls-cipher-suites", nil)
+	defer func() {
+		viper.Set("http-tls-certificate", "")
+		viper.Set("http-tls-key", "")
+	}()
+
+	algorithmRegistry, err := signature.NewAlgorithmRegistryConfig([]v1.PublicKeyDetails{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grpcServer, err := createGRPCServer(nil, nil, &TrivialCertificateAuthority{}, algorithmRegistry, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grpcServer.tlsCertWatcher != nil {
+		defer grpcServer.tlsCertWatcher.Close()
+	}
+
+	srv := createHTTPServer(context.Background(), addr, grpcServer, nil)
+	var wg sync.WaitGroup
+	srv.startListener(&wg)
+	defer srv.Shutdown(context.Background())
+
+	// Wait for the TLS listener to come up.
+	var ready bool
+	for i := 0; i < 50; i++ {
+		conn, derr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) // #nosec G402 -- test client
+		if derr == nil {
+			if conn.ConnectionState().Version != tls.VersionTLS13 {
+				t.Errorf("negotiated version = %#x, want %#x", conn.ConnectionState().Version, tls.VersionTLS13)
+			}
+			conn.Close()
+			ready = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("HTTPS listener did not become ready")
+	}
+
+	// A client capped at TLS 1.2 must be rejected by the 1.3 floor.
+	if _, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- test client
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+	}); err == nil {
+		t.Fatal("expected handshake to fail for TLS < 1.3")
 	}
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -238,3 +238,51 @@ To get the root certificate, call `curl -o fulcio.crt.pem http://localhost:5555/
 
 Set `SIGSTORE_CT_LOG_PUBLIC_KEY_FILE` with the path to a PEM or DER-encoded CT log public key.
 If using `docker-compose`, the public key is available at `config/ctfe/pubkey.pem`.
+
+## Serving over TLS
+
+By default Fulcio serves both the HTTP/REST and gRPC endpoints in cleartext, and is
+typically deployed behind a proxy or load balancer that terminates TLS. Fulcio can also
+terminate TLS itself on any serving path. This is useful when the hop between the
+terminator and the Fulcio pod is a separate trust boundary (for example a re-encrypting
+ingress), so that the OIDC bearer token and CSR are not sent in cleartext to the pod.
+
+All TLS flags are optional and default to today's behaviour when unset, so existing
+deployments are unaffected.
+
+### Serving material
+
+* `--grpc-tls-certificate` / `--grpc-tls-key`: serve TLS on the gRPC listener.
+* `--http-tls-certificate` / `--http-tls-key`: serve TLS on the HTTP/REST listener, and on
+  the shared listener in duplex mode.
+
+Each certificate and key must be provided together, and on-disk rotation is picked up
+without a restart.
+
+### Policy
+
+* `--tls-min-version`: minimum negotiated TLS version, `1.2` or `1.3`. When unset, every
+  TLS-enabled serving path defaults to a `1.3` floor. This is a floor, not a ceiling:
+  modern clients already negotiate 1.3, and lowering it only permits an older fallback.
+  Lower it to `1.2` for peers that cannot negotiate TLS 1.3, such as a TLS-inspecting
+  proxy, a compliance-pinned load balancer, or legacy OpenSSL tooling in front of Fulcio.
+  (`1.2` remains a current, non-deprecated version and matches Go's own stdlib server
+  default.)
+* `--tls-cipher-suites`: comma-separated list of allowed cipher suite names, using the Go
+  standard library spelling (for example `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`). Only
+  suites considered secure by Go are accepted. This applies to TLS 1.2 handshakes only; Go
+  fixes the TLS 1.3 suite set, so the flag has no effect at the default 1.3 floor and only
+  takes effect when the minimum version is lowered to 1.2.
+
+Both policy flags apply uniformly to every TLS-enabled serving path. Misconfiguration
+(a certificate without its key, an unsupported minimum version, or an unknown cipher name)
+fails at startup with a clear error.
+
+For example, to serve the REST endpoint over HTTPS with a TLS 1.2 floor:
+
+```
+go run main.go serve --ca ephemeralca --ct-log-url="" \
+  --http-tls-certificate /path/to/cert.pem --http-tls-key /path/to/key.pem \
+  --tls-min-version 1.2
+```
+

--- a/internal/tlspolicy/tlspolicy.go
+++ b/internal/tlspolicy/tlspolicy.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package tlspolicy resolves the configurable TLS policy shared by Fulcio's
+// gRPC, HTTP, and duplex serving paths.
+package tlspolicy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ALPNProtocols advertises HTTP/2 (required by gRPC) ahead of HTTP/1.1 on
+// TLS-enabled HTTP and duplex listeners.
+var ALPNProtocols = []string{"h2", "http/1.1"}
+
+// DefaultMinVersion is the TLS floor applied when --tls-min-version is unset.
+// TLS 1.3 keeps every serving path default-secure; operators fronted by peers
+// that cannot negotiate it can lower the floor to 1.2 via --tls-min-version.
+const DefaultMinVersion = tls.VersionTLS13
+
+// Policy is the resolved TLS policy for a serving path.
+type Policy struct {
+	MinVersion uint16
+	// CipherSuites restricts the allowed TLS 1.2 suites; nil keeps the
+	// crypto/tls default and has no effect on TLS 1.3.
+	CipherSuites []uint16
+}
+
+var supportedVersions = map[string]uint16{
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
+
+func supportedVersionNames() []string {
+	names := make([]string, 0, len(supportedVersions))
+	for name := range supportedVersions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ParseVersion maps a minimum TLS version string to its crypto/tls constant.
+func ParseVersion(v string) (uint16, error) {
+	if id, ok := supportedVersions[strings.TrimSpace(v)]; ok {
+		return id, nil
+	}
+	return 0, fmt.Errorf("unsupported --tls-min-version %q (supported: %s)", v, strings.Join(supportedVersionNames(), ", "))
+}
+
+// ParseCipherSuites resolves cipher suite names to their crypto/tls IDs. Only
+// suites reported as secure by crypto/tls are accepted; names must match the
+// crypto/tls spelling (e.g. TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256).
+func ParseCipherSuites(names []string) ([]uint16, error) {
+	byName := make(map[string]uint16, len(tls.CipherSuites()))
+	for _, c := range tls.CipherSuites() {
+		byName[c.Name] = c.ID
+	}
+	var ids []uint16
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		id, ok := byName[n]
+		if !ok {
+			return nil, fmt.Errorf("unknown or insecure --tls-cipher-suites entry %q", n)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// Resolve builds a Policy from raw flag values. An empty minVersion selects
+// DefaultMinVersion.
+func Resolve(minVersion string, cipherSuites []string) (Policy, error) {
+	p := Policy{MinVersion: DefaultMinVersion}
+	if minVersion != "" {
+		mv, err := ParseVersion(minVersion)
+		if err != nil {
+			return Policy{}, err
+		}
+		p.MinVersion = mv
+	}
+	if len(cipherSuites) > 0 {
+		cs, err := ParseCipherSuites(cipherSuites)
+		if err != nil {
+			return Policy{}, err
+		}
+		p.CipherSuites = cs
+	}
+	return p, nil
+}

--- a/internal/tlspolicy/tlspolicy_test.go
+++ b/internal/tlspolicy/tlspolicy_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tlspolicy
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    uint16
+		wantErr bool
+	}{
+		{"1.2", tls.VersionTLS12, false},
+		{"1.3", tls.VersionTLS13, false},
+		{"  1.3  ", tls.VersionTLS13, false},
+		{"1.1", 0, true},
+		{"1.0", 0, true},
+		{"TLS1.2", 0, true},
+		{"VersionTLS12", 0, true},
+		{"garbage", 0, true},
+	}
+	for _, tc := range tests {
+		got, err := ParseVersion(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseVersion(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if !tc.wantErr && got != tc.want {
+			t.Errorf("ParseVersion(%q) = %#x, want %#x", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	// A known-secure TLS 1.2 suite reported by tls.CipherSuites().
+	secure := "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+
+	t.Run("valid suites", func(t *testing.T) {
+		ids, err := ParseCipherSuites([]string{secure})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Fatalf("unexpected ids: %v", ids)
+		}
+	})
+
+	t.Run("blank entries skipped", func(t *testing.T) {
+		ids, err := ParseCipherSuites([]string{"", "  ", secure})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 id, got %v", ids)
+		}
+	})
+
+	t.Run("unknown suite rejected", func(t *testing.T) {
+		if _, err := ParseCipherSuites([]string{"NOT_A_REAL_SUITE"}); err == nil {
+			t.Fatal("expected error for unknown suite")
+		}
+	})
+
+	t.Run("insecure suite rejected", func(t *testing.T) {
+		// Present only in tls.InsecureCipherSuites(), so it must be rejected.
+		if _, err := ParseCipherSuites([]string{"TLS_RSA_WITH_AES_128_CBC_SHA"}); err == nil {
+			t.Fatal("expected insecure suite to be rejected")
+		}
+	})
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		p, err := Resolve("", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %#x, want default %#x", p.MinVersion, tls.VersionTLS13)
+		}
+		if p.CipherSuites != nil {
+			t.Errorf("CipherSuites = %v, want nil", p.CipherSuites)
+		}
+	})
+
+	t.Run("override min and ciphers", func(t *testing.T) {
+		p, err := Resolve("1.2", []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %#x, want %#x", p.MinVersion, tls.VersionTLS12)
+		}
+		if len(p.CipherSuites) != 1 {
+			t.Errorf("CipherSuites = %v, want one entry", p.CipherSuites)
+		}
+	})
+
+	t.Run("invalid min version errors", func(t *testing.T) {
+		if _, err := Resolve("1.1", nil); err == nil {
+			t.Fatal("expected error for unsupported version")
+		}
+	})
+
+	t.Run("invalid cipher suite errors", func(t *testing.T) {
+		if _, err := Resolve("", []string{"NOT_A_REAL_SUITE"}); err == nil {
+			t.Fatal("expected error for unknown cipher suite")
+		}
+	})
+}


### PR DESCRIPTION
Adds a shared TLS policy layer so the HTTP/REST listener, the gRPC listener, and the duplex listener can all terminate TLS with a consistent, configurable policy.

New flags:

```
--http-tls-certificate / --http-tls-key  enable TLS on the HTTP endpoint and the shared listener
--tls-min-version                        minimum TLS version for all serving paths (1.2 or 1.3)
--tls-cipher-suites                      allowed TLS 1.2 cipher suite names applied to all serving paths
```

The min-version and cipher-suite parsers reject unsupported versions and insecure/unknown suites, and `validateTLSFlags` fails fast at startup on mismatched certificate/key pairs. The gRPC listener keeps its existing fsnotify cert hot-reload; the HTTP/REST and shared duplex listeners load the certificate once at startup, so rotating it needs a restart.

## Summary

Closes #2415.

Today Fulcio can only terminate TLS on the gRPC listener (`--grpc-tls-certificate` / `--grpc-tls-key`); the HTTP/REST endpoint is always served in plaintext, and the minimum TLS version and cipher suites are not configurable on any path. This makes it hard to run Fulcio behind operators/platforms that need TLS terminated at the component and want to enforce an organization-wide TLS policy.

This PR introduces a small shared TLS policy layer (`internal/tlspolicy`) that is applied uniformly to all three serving paths, the two-listener HTTP and gRPC servers and the duplex (single shared listener) server:

- TLS on the HTTP endpoint via `--http-tls-certificate` / `--http-tls-key`. In duplex mode the same certificate secures the shared listener; ALPN advertises `h2` then `http/1.1` so gRPC-over-HTTP/2 still negotiates correctly, and the loopback gateway dial is upgraded to TLS.
- Configurable minimum TLS version via `--tls-min-version` (`1.2` or `1.3`). When unset, every serving path defaults to a TLS 1.3 floor. gRPC already required TLS 1.3, so this only raises the new HTTP/duplex paths and introduces no regression; deployments fronted by a peer that cannot negotiate TLS 1.3 can opt down with `--tls-min-version 1.2`.
- Configurable TLS 1.2 cipher suites via `--tls-cipher-suites`, restricted to the secure suites reported by the Go standard library (`crypto/tls`); insecure/unknown names are rejected. This has no effect at the default TLS 1.3 floor, whose suite set is fixed by Go, and only takes effect when the minimum version is lowered to 1.2.
- Fail-fast validation (`validateTLSFlags`) at startup: a certificate without its matching key (or vice versa) on either path, an unsupported version, or an unknown cipher suite name is rejected before serving.
- Certificate rotation: the gRPC listener keeps its existing fsnotify-based hot-reload. The HTTP/REST listener and the shared duplex listener load their certificate once at startup, so rotating it on disk requires a restart (per review feedback — mid-process reloads are avoided in favor of a restart).

All flags are opt-in and default to the current behavior, so this is backward compatible: without the new flags, Fulcio serves exactly as it does today.

## How to test

- Run `go test ./internal/tlspolicy/... ./cmd/app/...` — `internal/tlspolicy` covers version/cipher parsing and policy resolution; `cmd/app` covers flag validation plus end-to-end TLS: `TestDuplexTLS` starts a TLS-enabled duplex server and confirms `GET /healthz` succeeds over HTTPS while a client offering below the minimum version is rejected, and `TestCreateHTTPServerTLS` / `TestStartListenerTLS` cover the HTTP TLS-termination path.
- Manually: start `fulcio serve` with `--http-tls-certificate`/`--http-tls-key` (optionally `--tls-min-version 1.2`) and confirm the REST endpoint is served over HTTPS and that a sub-minimum client handshake is refused. To verify rotation behavior, replace the cert/key on disk while running — the listener keeps serving the old cert until Fulcio is restarted.

#### Release Note

```release-note
Added TLS support for the HTTP endpoint and a configurable TLS policy across all serving paths. New `serve` flags: `--http-tls-certificate` and `--http-tls-key` enable TLS on the HTTP/REST endpoint (and the shared listener in duplex mode), `--tls-min-version` sets the minimum TLS version (1.2 or 1.3, defaulting to 1.3), and `--tls-cipher-suites` restricts the allowed TLS 1.2 cipher suites. All flags are opt-in. Existing deployments are unaffected. The gRPC listener continues to hot-reload its certificate; the HTTP/REST and duplex listeners load the certificate at startup and require a restart to pick up a rotated certificate.
```

#### Documentation

Updated `docs/setup.md` with a new "Serving over TLS" section covering the `--grpc-tls-*`, `--http-tls-*`, `--tls-min-version`, and `--tls-cipher-suites` flags, certificate-rotation behavior, and an example. No change to https://docs.sigstore.dev is required.
